### PR TITLE
Fix mlflow import and add --version flag

### DIFF
--- a/src/deployml/cli/cli.py
+++ b/src/deployml/cli/cli.py
@@ -454,7 +454,29 @@ import time
 import json
 from datetime import datetime, timedelta
 
-cli = typer.Typer()
+def get_version():
+    """Get version from package metadata"""
+    try:
+        from importlib.metadata import version
+        return version("deployml-core")
+    except Exception:
+        return "version unknown"
+
+cli = typer.Typer(invoke_without_command=True)
+
+@cli.callback()
+def cli_callback(
+    ctx: typer.Context,
+    version: bool = typer.Option(False, "--version", "-v", help="Show version and exit"),
+):
+    """DeployML CLI - Infrastructure for academia with cost analysis"""
+    if version:
+        typer.echo(f"deployml {get_version()}")
+        raise typer.Exit()
+    if ctx.invoked_subcommand is None:
+        # No command provided, show help
+        typer.echo(ctx.get_help())
+        raise typer.Exit()
 
 
 @cli.command()

--- a/src/deployml/notebook/stack.py
+++ b/src/deployml/notebook/stack.py
@@ -1,11 +1,12 @@
 import json
 import subprocess
 from pathlib import Path
-from typing import Dict, Any
+from typing import Dict, Any, TYPE_CHECKING
 from datetime import datetime, timezone
 import pandas as pd
-import mlflow
-from mlflow.tracking import MlflowClient
+
+if TYPE_CHECKING:
+    from mlflow.tracking import MlflowClient
 
 from .urls import ServiceURLs
 from .display import display_services_table
@@ -85,9 +86,17 @@ class DeploymentStack:
             return ServiceURLs()
     
     @property  
-    def mlflow(self) -> MlflowClient:
-        """Get pre-configured MLflow client"""
+    def mlflow(self) -> 'MlflowClient':
+        """Get pre-configured MLflow client (lazy import)"""
         if self._mlflow_client is None:
+            try:
+                import mlflow
+                from mlflow.tracking import MlflowClient
+            except ImportError:
+                raise ImportError(
+                    "mlflow is required for MLflow client access. "
+                    "Install it with: pip install mlflow"
+                )
             if self.urls.mlflow:
                 mlflow.set_tracking_uri(self.urls.mlflow)
                 self._mlflow_client = MlflowClient(self.urls.mlflow)


### PR DESCRIPTION
### Problem
- `deployml --version` failed with `ModuleNotFoundError: No module named 'mlflow'` because mlflow was imported at module load time.
- CLI lacked a `--version` flag

### Solution
- Made mlflow import lazy in `notebook/stack.py` - only imports when the `mlflow` property is accessed
- Added `--version` / `-v` flag to CLI using Typer callback
- Version is read from package metadata with fallback
