### PR TITLE
Issue45

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 
 [project]
 name = "deployml-core"
-version = "0.0.1"
+version = "0.0.42"
 description = "Infra for academia"
 authors = [
     {name = "Drew Hoang", email = "codentell@gmail.com"},

--- a/src/deployml/cli/cli.py
+++ b/src/deployml/cli/cli.py
@@ -460,6 +460,18 @@ def get_version():
         from importlib.metadata import version
         return version("deployml-core")
     except Exception:
+        try:
+            result = subprocess.run(
+                ["git", "describe", "--tags", "--abbrev=0"],
+                capture_output=True,
+                text=True,
+                cwd=Path(__file__).parent.parent.parent.parent
+            )
+            if result.returncode == 0:
+                git_version = result.stdout.strip().lstrip("v")
+                return git_version
+        except Exception:
+            pass
         return "version unknown"
 
 cli = typer.Typer(invoke_without_command=True)

--- a/src/deployml/diagnostics/doctor.py
+++ b/src/deployml/diagnostics/doctor.py
@@ -7,7 +7,14 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 import json
 import importlib
-import pkg_resources
+try:
+    from importlib.metadata import version as get_package_version_metadata
+except ImportError:
+    # Fallback for Python < 3.8
+    try:
+        from importlib_metadata import version as get_package_version_metadata
+    except ImportError:
+        get_package_version_metadata = None
 from dataclasses import dataclass
 from enum import Enum
 import re
@@ -190,8 +197,11 @@ class DeployMLDoctor:
     def _get_package_version(self, package_name: str) -> Optional[str]:
         """Get version of installed package"""
         try:
-            return pkg_resources.get_distribution(package_name).version
-        except:
+            if get_package_version_metadata:
+                return get_package_version_metadata(package_name)
+            else:
+                return None
+        except Exception:
             return None
     
     def _check_docker(self):


### PR DESCRIPTION
Use importlib.metadata instead of deprecated pkg_resources to solve [https://github.com/deployml-core/deployml/issues/45](https://github.com/deployml-core/deployml/issues/45).