### PR TITLE
Windows Compatibility - GCP + GKE (Kubernetes, Minikube)

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -57,11 +57,45 @@ The doctor checks tool versions, authentication, ADC, the `bq` CLI, enabled APIs
 
 ## Platform notes
 
-deployml is tested on macOS and Linux. Windows users can run it with these caveats:
+deployml runs on macOS, Linux, and native Windows. The CLI commands are identical
+across all three. The engine detects the operating system and adapts underneath, so
+you type the same `deployml` commands everywhere.
 
-- The auth commands above and all `deployml` CLI calls work the same in PowerShell, cmd, and WSL.
-- `export PATH=...` examples in the tutorials are bash. On PowerShell use `$env:PATH = "..." + $env:PATH`. On cmd use `set PATH=...;%PATH%`.
-- Docker Desktop on Windows uses the WSL2 backend by default. `deployml build-images` against Cloud Build does not need a local Docker daemon, so the safest path is to skip local builds and let Cloud Build do the work.
-- If you clone the repo on Windows, the included `.gitattributes` forces shell scripts and Dockerfiles to LF line endings. Without this, `docker build` would fail inside containers with `exec format error`.
+### Windows
+
+deployml works on native Windows in PowerShell or cmd. A few setup notes keep it
+smooth and let it work out of the box:
+
+- Toolchain. Install native Windows builds of Python 3.11 or newer, Git for
+  Windows, the gcloud SDK, Terraform, and Docker Desktop. For the Kubernetes paths
+  also install minikube and run `gcloud components install gke-gcloud-auth-plugin`.
+  `deployml doctor` checks the core tools.
+- Python. Install from python.org, then create the virtual environment with the
+  launcher, `py -3.11 -m venv .venv`. A bare `python` on a fresh Windows often
+  resolves to the Microsoft Store stub, which is not a usable interpreter.
+- Git for Windows is required, not optional. It provides the `bash` that the Cloud
+  SQL readiness step runs under during `deployml deploy`. Confirm `bash --version`
+  resolves before you deploy.
+- Keep the project and its working directory off OneDrive. OneDrive holds file
+  handles open and can make workspace cleanup on `deployml destroy` fail with a
+  PermissionError. A path such as `C:\dev\your-project` avoids this.
+- gcloud, bq, and gsutil ship as `.cmd` wrappers on Windows. deployml resolves and
+  invokes them correctly for you. If you run gcloud yourself in PowerShell and see
+  "running scripts is disabled", call `gcloud.cmd` instead of `gcloud`, or run it
+  from cmd.
+
+### Path syntax across shells
+
+- The `export PATH=...` examples in the tutorials are bash. In PowerShell use
+  `$env:PATH = "...;" + $env:PATH`. In cmd use `set PATH=...;%PATH%`.
+
+### Docker and line endings
+
+- Docker Desktop on Windows uses the WSL2 backend by default. The Cloud Run path
+  builds images with Cloud Build and does not need a local Docker daemon, so for
+  Cloud Run you can skip local builds. Docker is needed only for the minikube path.
+- If you clone the repo on Windows, the included `.gitattributes` forces shell
+  scripts and Dockerfiles to LF line endings. Without this, `docker build` would
+  fail inside containers with `exec format error`.
 
 - [Get Started →](tutorials/overview.md)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -83,6 +83,17 @@ smooth and let it work out of the box:
   invokes them correctly for you. If you run gcloud yourself in PowerShell and see
   "running scripts is disabled", call `gcloud.cmd` instead of `gcloud`, or run it
   from cmd.
+- minikube on Windows uses the Docker Desktop driver. The service URL deployml
+  prints sits on minikube's internal network and is not reachable from the Windows
+  host directly. Reach it with `minikube tunnel`, `minikube service <name> --url`,
+  or `kubectl port-forward svc/<name> <local>:<port>`. MLflow on minikube wants at
+  least 4 GB, so start with `minikube start --memory=4096 --cpus=2` on a machine
+  that can spare it; an 8 GB machine that is also running Docker Desktop and other
+  apps may not have room for the MLflow pod.
+- Installing a gcloud component such as the GKE auth plugin with
+  `gcloud components install` may, in a non interactive shell, ask you to set
+  `CLOUDSDK_PYTHON` first; run `gcloud components copy-bundled-python` and set the
+  printed path, or just run the install from an interactive prompt.
 
 ### Path syntax across shells
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,8 +43,6 @@ markdown_extensions:
   - pymdownx.emoji:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
-
-markdown_extensions:
   - pymdownx.highlight:
       anchor_linenums: true
       line_spans: __span

--- a/src/deployml/api.py
+++ b/src/deployml/api.py
@@ -29,11 +29,11 @@ Example usage:
     )
 """
 import json
-import subprocess
 from pathlib import Path
 from datetime import datetime, timedelta, timezone
 from typing import Optional, Dict, Any
 
+from .utils.platform_compat import run_tool
 from .utils.teardown import (
     calculate_cron_from_timestamp,
     load_deployment_metadata,
@@ -68,9 +68,9 @@ def get_teardown_status(
     """
     scheduler_job_name = f"deployml-teardown-{workspace_name}"
     
-    result = subprocess.run(
-        ["gcloud", "scheduler", "jobs", "describe", scheduler_job_name,
-         "--project", project_id, "--location", region, "--format", "json"],
+    result = run_tool(
+        "gcloud", ["scheduler", "jobs", "describe", scheduler_job_name,
+                   "--project", project_id, "--location", region, "--format", "json"],
         capture_output=True,
         text=True,
     )
@@ -141,9 +141,9 @@ def update_teardown_schedule(
     scheduler_job_name = f"deployml-teardown-{workspace_name}"
     
     # Check if job exists and get current timezone
-    result = subprocess.run(
-        ["gcloud", "scheduler", "jobs", "describe", scheduler_job_name,
-         "--project", project_id, "--location", region, "--format", "json"],
+    result = run_tool(
+        "gcloud", ["scheduler", "jobs", "describe", scheduler_job_name,
+                   "--project", project_id, "--location", region, "--format", "json"],
         capture_output=True,
         text=True,
     )
@@ -168,9 +168,10 @@ def update_teardown_schedule(
     new_cron_schedule = calculate_cron_from_timestamp(teardown_scheduled_timestamp)
     
     # Update Cloud Scheduler job
-    update_result = subprocess.run(
+    update_result = run_tool(
+        "gcloud",
         [
-            "gcloud", "scheduler", "jobs", "update", "http", scheduler_job_name,
+            "scheduler", "jobs", "update", "http", scheduler_job_name,
             "--location", region,
             "--schedule", new_cron_schedule,
             "--time-zone", time_zone,
@@ -231,9 +232,9 @@ def cancel_teardown(
     """
     scheduler_job_name = f"deployml-teardown-{workspace_name}"
     
-    result = subprocess.run(
-        ["gcloud", "scheduler", "jobs", "delete", scheduler_job_name,
-         "--project", project_id, "--location", region, "--quiet"],
+    result = run_tool(
+        "gcloud", ["scheduler", "jobs", "delete", scheduler_job_name,
+                   "--project", project_id, "--location", region, "--quiet"],
         capture_output=True,
         text=True,
     )

--- a/src/deployml/cli/cli.py
+++ b/src/deployml/cli/cli.py
@@ -1,7 +1,6 @@
 import sys
 import yaml
 import typer
-import shutil
 import re
 import importlib.resources as pkg_resources
 from deployml.utils.banner import display_banner
@@ -46,7 +45,7 @@ from deployml.utils.helpers import (
     run_terraform_with_loading_bar,
     _create_docker_folder,
 )
-from deployml.utils.platform_compat import run_tool, resolve_tool, configure_console_encoding
+from deployml.utils.platform_compat import run_tool, resolve_tool, configure_console_encoding, robust_rmtree
 from deployml.utils.infracost import (
     check_infracost_available,
     run_infracost_analysis,
@@ -1896,7 +1895,7 @@ def destroy(
 
             if clean_workspace:
                 typer.echo(" Cleaning workspace...")
-                shutil.rmtree(DEPLOYML_DIR)
+                robust_rmtree(DEPLOYML_DIR)
                 typer.echo(" Workspace cleaned")
             elif yes or typer.confirm("Clean up Terraform state files?"):
                 # --yes propagates to the cleanup confirm so scripted runs do not hang

--- a/src/deployml/cli/cli.py
+++ b/src/deployml/cli/cli.py
@@ -2,7 +2,6 @@ import sys
 import yaml
 import typer
 import shutil
-import subprocess
 import re
 import importlib.resources as pkg_resources
 from deployml.utils.banner import display_banner
@@ -47,6 +46,7 @@ from deployml.utils.helpers import (
     run_terraform_with_loading_bar,
     _create_docker_folder,
 )
+from deployml.utils.platform_compat import run_tool, resolve_tool
 from deployml.utils.infracost import (
     check_infracost_available,
     run_infracost_analysis,
@@ -81,8 +81,8 @@ def upload_terraform_files_to_gcs(terraform_dir: Path, project_id: str, workspac
     try:
         # Get terraform files bucket from Terraform state
         # The bucket is created by the teardown module
-        state_proc = subprocess.run(
-            ["terraform", "state", "list"],
+        state_proc = run_tool(
+            "terraform", ["state", "list"],
             cwd=terraform_dir,
             capture_output=True,
             text=True,
@@ -104,8 +104,8 @@ def upload_terraform_files_to_gcs(terraform_dir: Path, project_id: str, workspac
             return
         
         # Get bucket name from state
-        show_proc = subprocess.run(
-            ["terraform", "state", "show", bucket_resource],
+        show_proc = run_tool(
+            "terraform", ["state", "show", bucket_resource],
             cwd=terraform_dir,
             capture_output=True,
             text=True,
@@ -160,7 +160,6 @@ def extract_resource_manifest(terraform_dir: Path, project_id: str, workspace_na
     Returns a manifest dictionary with all resources that need to be deleted.
     """
     import json
-    import subprocess
     from urllib.parse import urlparse
     
     manifest = {
@@ -181,13 +180,13 @@ def extract_resource_manifest(terraform_dir: Path, project_id: str, workspace_na
     }
     
     # Get Terraform outputs
-    output_proc = subprocess.run(
-        ["terraform", "output", "-json"],
+    output_proc = run_tool(
+        "terraform", ["output", "-json"],
         cwd=terraform_dir,
         capture_output=True,
         text=True,
     )
-    
+
     if output_proc.returncode == 0:
         outputs = json.loads(output_proc.stdout)
         
@@ -217,8 +216,8 @@ def extract_resource_manifest(terraform_dir: Path, project_id: str, workspace_na
                     })
     
     # Query Terraform state for additional resources
-    state_proc = subprocess.run(
-        ["terraform", "state", "list"],
+    state_proc = run_tool(
+        "terraform", ["state", "list"],
         cwd=terraform_dir,
         capture_output=True,
         text=True,
@@ -231,8 +230,8 @@ def extract_resource_manifest(terraform_dir: Path, project_id: str, workspace_na
             try:
                 # Cloud Run services (v1 and v2)
                 if 'google_cloud_run_service' in resource and 'google_cloud_run_v2_job' not in resource:
-                    show_proc = subprocess.run(
-                        ["terraform", "state", "show", resource],
+                    show_proc = run_tool(
+                        "terraform", ["state", "show", resource],
                         cwd=terraform_dir,
                         capture_output=True,
                         text=True,
@@ -268,8 +267,8 @@ def extract_resource_manifest(terraform_dir: Path, project_id: str, workspace_na
                 
                 # Cloud Run Jobs
                 elif 'google_cloud_run_v2_job' in resource:
-                    show_proc = subprocess.run(
-                        ["terraform", "state", "show", resource],
+                    show_proc = run_tool(
+                        "terraform", ["state", "show", resource],
                         cwd=terraform_dir,
                         capture_output=True,
                         text=True,
@@ -287,8 +286,8 @@ def extract_resource_manifest(terraform_dir: Path, project_id: str, workspace_na
                 
                 # Cloud Scheduler jobs
                 elif 'google_cloud_scheduler_job' in resource:
-                    show_proc = subprocess.run(
-                        ["terraform", "state", "show", resource],
+                    show_proc = run_tool(
+                        "terraform", ["state", "show", resource],
                         cwd=terraform_dir,
                         capture_output=True,
                         text=True,
@@ -312,8 +311,8 @@ def extract_resource_manifest(terraform_dir: Path, project_id: str, workspace_na
                 
                 # Pub/Sub topics
                 elif 'google_pubsub_topic' in resource:
-                    show_proc = subprocess.run(
-                        ["terraform", "state", "show", resource],
+                    show_proc = run_tool(
+                        "terraform", ["state", "show", resource],
                         cwd=terraform_dir,
                         capture_output=True,
                         text=True,
@@ -330,8 +329,8 @@ def extract_resource_manifest(terraform_dir: Path, project_id: str, workspace_na
                 
                 # Secret Manager secrets
                 elif 'google_secret_manager_secret' in resource:
-                    show_proc = subprocess.run(
-                        ["terraform", "state", "show", resource],
+                    show_proc = run_tool(
+                        "terraform", ["state", "show", resource],
                         cwd=terraform_dir,
                         capture_output=True,
                         text=True,
@@ -348,8 +347,8 @@ def extract_resource_manifest(terraform_dir: Path, project_id: str, workspace_na
                 
                 # Service accounts (only teardown ones to avoid deleting user SAs)
                 elif 'google_service_account' in resource and 'teardown' in resource:
-                    show_proc = subprocess.run(
-                        ["terraform", "state", "show", resource],
+                    show_proc = run_tool(
+                        "terraform", ["state", "show", resource],
                         cwd=terraform_dir,
                         capture_output=True,
                         text=True,
@@ -366,8 +365,8 @@ def extract_resource_manifest(terraform_dir: Path, project_id: str, workspace_na
                 
                 # Cloud Build triggers
                 elif 'google_cloudbuild_trigger' in resource:
-                    show_proc = subprocess.run(
-                        ["terraform", "state", "show", resource],
+                    show_proc = run_tool(
+                        "terraform", ["state", "show", resource],
                         cwd=terraform_dir,
                         capture_output=True,
                         text=True,
@@ -411,8 +410,8 @@ def upload_resource_manifest(manifest: dict, terraform_dir: Path, project_id: st
     
     try:
         # Get bucket name from Terraform state (same logic as upload_terraform_files_to_gcs)
-        state_proc = subprocess.run(
-            ["terraform", "state", "list"],
+        state_proc = run_tool(
+            "terraform", ["state", "list"],
             cwd=terraform_dir,
             capture_output=True,
             text=True,
@@ -430,8 +429,8 @@ def upload_resource_manifest(manifest: dict, terraform_dir: Path, project_id: st
         if not bucket_resource:
             raise Exception("Teardown module bucket not found in state")
         
-        show_proc = subprocess.run(
-            ["terraform", "state", "show", bucket_resource],
+        show_proc = run_tool(
+            "terraform", ["state", "show", bucket_resource],
             cwd=terraform_dir,
             capture_output=True,
             text=True,
@@ -563,8 +562,8 @@ def get_version():
         return version("deployml-core")
     except Exception:
         try:
-            result = subprocess.run(
-                ["git", "describe", "--tags", "--abbrev=0"],
+            result = run_tool(
+                "git", ["describe", "--tags", "--abbrev=0"],
                 capture_output=True,
                 text=True,
                 cwd=Path(__file__).parent.parent.parent.parent
@@ -669,9 +668,9 @@ def doctor(
             typer.echo(
                 f"\n Checking enabled APIs for project: {project_id} ..."
             )
-            result = subprocess.run(
+            result = run_tool(
+                "gcloud",
                 [
-                    "gcloud",
                     "services",
                     "list",
                     "--enabled",
@@ -1343,16 +1342,16 @@ def deploy(
     # Auth and ADC were already preflighted above, so just point gcloud at the project.
     typer.echo(f" Deploying {config.get('name', workspace_name)} to {cloud}...")
 
-    subprocess.run(
-        ["gcloud", "config", "set", "project", project_id],
+    run_tool(
+        "gcloud", ["config", "set", "project", project_id],
         cwd=DEPLOYML_TERRAFORM_DIR,
     )
 
     typer.echo(" Initializing Terraform...")
     # Capture stderr so init failures (state lock, missing ADC, bucket perms)
     # surface a real message instead of a silent exit.
-    init_proc = subprocess.run(
-        ["terraform", "init"],
+    init_proc = run_tool(
+        "terraform", ["init"],
         cwd=DEPLOYML_TERRAFORM_DIR,
         capture_output=True,
         text=True,
@@ -1364,8 +1363,8 @@ def deploy(
         raise typer.Exit(code=1)
 
     typer.echo(" Planning deployment...")
-    result = subprocess.run(
-        ["terraform", "plan"],
+    result = run_tool(
+        "terraform", ["plan"],
         cwd=DEPLOYML_TERRAFORM_DIR,
         capture_output=True,
         text=True,
@@ -1443,8 +1442,8 @@ def deploy(
         estimated_time = estimate_terraform_time(result.stdout, "apply")
         typer.echo(f" Applying changes... (Estimated time: {estimated_time})")
         # Re-init before apply; capture stderr to surface failures
-        init_proc2 = subprocess.run(
-            ["terraform", "init"],
+        init_proc2 = run_tool(
+            "terraform", ["init"],
             cwd=DEPLOYML_TERRAFORM_DIR,
             capture_output=True,
             text=True,
@@ -1507,9 +1506,10 @@ def deploy(
                 scheduler_job_name = f"deployml-teardown-{workspace_name}"
                 try:
                     typer.echo(f" Updating teardown schedule to: {teardown_at.strftime('%Y-%m-%d %H:%M:%S UTC')}")
-                    update_result = subprocess.run(
+                    update_result = run_tool(
+                        "gcloud",
                         [
-                            "gcloud", "scheduler", "jobs", "update", "http", scheduler_job_name,
+                            "scheduler", "jobs", "update", "http", scheduler_job_name,
                             "--location", region,
                             "--schedule", correct_cron_schedule,
                             "--time-zone", time_zone,
@@ -1544,8 +1544,8 @@ def deploy(
                 typer.echo(f"   To cancel: deployml teardown cancel --config-path {config_path}")
             
             # Show all Terraform outputs in a user-friendly way
-            output_proc = subprocess.run(
-                ["terraform", "output", "-json"],
+            output_proc = run_tool(
+                "terraform", ["output", "-json"],
                 cwd=DEPLOYML_TERRAFORM_DIR,
                 capture_output=True,
                 text=True,
@@ -1662,8 +1662,8 @@ def get_urls(
         typer.echo(f" No deployment found at {terraform_dir}. Run 'deployml deploy' first.")
         raise typer.Exit(code=1)
 
-    output_proc = subprocess.run(
-        ["terraform", "output", "-json"],
+    output_proc = run_tool(
+        "terraform", ["output", "-json"],
         cwd=terraform_dir,
         capture_output=True,
         text=True,
@@ -1724,9 +1724,9 @@ def get_urls(
         # Grafana admin password
         grafana_secret = outputs.get("grafana_admin_password_secret_id", {}).get("value", "")
         if grafana_secret and project_id:
-            fetch = subprocess.run(
-                ["gcloud", "secrets", "versions", "access", "latest",
-                 "--secret", grafana_secret, "--project", project_id],
+            fetch = run_tool(
+                "gcloud", ["secrets", "versions", "access", "latest",
+                           "--secret", grafana_secret, "--project", project_id],
                 capture_output=True, text=True,
             )
             if fetch.returncode == 0:
@@ -1810,8 +1810,8 @@ def destroy(
         typer.echo(f" Destroying infrastructure...")
 
         # Set GCP project
-        subprocess.run(
-            ["gcloud", "config", "set", "project", project_id],
+        run_tool(
+            "gcloud", ["config", "set", "project", project_id],
             cwd=DEPLOYML_TERRAFORM_DIR,
         )
 
@@ -1819,30 +1819,30 @@ def destroy(
         # before attempting to destroy Cloud SQL — otherwise active connections
         # prevent database/user deletion and the destroy fails.
         region = config.get("provider", {}).get("region", "us-central1")
-        cr_result = subprocess.run(
-            ["gcloud", "run", "services", "list",
-             "--project", project_id,
-             "--region", region,
-             "--format", "value(metadata.name)"],
+        cr_result = run_tool(
+            "gcloud", ["run", "services", "list",
+                       "--project", project_id,
+                       "--region", region,
+                       "--format", "value(metadata.name)"],
             capture_output=True, text=True
         )
         if cr_result.returncode == 0:
             services = [s.strip() for s in cr_result.stdout.splitlines() if s.strip()]
             for service in services:
                 typer.echo(f" Deleting Cloud Run service: {service}")
-                subprocess.run(
-                    ["gcloud", "run", "services", "delete", service,
-                     "--project", project_id,
-                     "--region", region,
-                     "--quiet"],
+                run_tool(
+                    "gcloud", ["run", "services", "delete", service,
+                               "--project", project_id,
+                               "--region", region,
+                               "--quiet"],
                     capture_output=True,
                 )
 
         # Remove Cloud SQL databases and user from Terraform state so Terraform
         # doesn't try to delete them individually — the instance deletion handles
         # that automatically, avoiding active-connection errors on destroy.
-        state_result = subprocess.run(
-            ["terraform", "state", "list"],
+        state_result = run_tool(
+            "terraform", ["state", "list"],
             cwd=DEPLOYML_TERRAFORM_DIR,
             capture_output=True,
             text=True,
@@ -1857,8 +1857,8 @@ def destroy(
             ]
             for resource in resources_to_remove:
                 typer.echo(f" Removing from state: {resource}")
-                subprocess.run(
-                    ["terraform", "state", "rm", resource],
+                run_tool(
+                    "terraform", ["state", "rm", resource],
                     cwd=DEPLOYML_TERRAFORM_DIR,
                     capture_output=True,
                 )
@@ -1867,7 +1867,7 @@ def destroy(
         cmd = ["terraform", "destroy", "--auto-approve"]
 
         # Run destroy
-        result = subprocess.run(cmd, cwd=DEPLOYML_TERRAFORM_DIR, check=False)
+        result = run_tool(cmd[0], cmd[1:], cwd=DEPLOYML_TERRAFORM_DIR, check=False)
 
         if result.returncode == 0:
             typer.echo(" Infrastructure destroyed successfully!")
@@ -1877,9 +1877,9 @@ def destroy(
             region = config.get("provider", {}).get("region", "us-central1")
             ar_repo = "mlops-images"
             typer.echo(f" Removing Artifact Registry repo {ar_repo}...")
-            subprocess.run(
-                ["gcloud", "artifacts", "repositories", "delete", ar_repo,
-                 "--location", region, "--project", project_id, "--quiet"],
+            run_tool(
+                "gcloud", ["artifacts", "repositories", "delete", ar_repo,
+                           "--location", region, "--project", project_id, "--quiet"],
                 capture_output=True,
             )
 
@@ -1889,8 +1889,8 @@ def destroy(
             # recreates it on the next build if needed.
             cb_bucket = f"gs://{project_id}_cloudbuild"
             typer.echo(f" Removing Cloud Build staging bucket {cb_bucket}...")
-            subprocess.run(
-                ["gcloud", "storage", "rm", "--recursive", cb_bucket, "--quiet"],
+            run_tool(
+                "gcloud", ["storage", "rm", "--recursive", cb_bucket, "--quiet"],
                 capture_output=True,
             )
 
@@ -1945,8 +1945,8 @@ def status(
     marker = deployml_dir / ".project_id"
     if marker.exists():
         typer.echo(f"Project: {marker.read_text().strip()}")
-    out_proc = subprocess.run(
-        ["terraform", "output", "-json"],
+    out_proc = run_tool(
+        "terraform", ["output", "-json"],
         cwd=tf_dir, capture_output=True, text=True,
     )
     if out_proc.returncode == 0 and out_proc.stdout.strip():
@@ -2007,9 +2007,9 @@ def cancel_teardown(config: dict, deployml_dir: Path, workspace_name: str):
     # Delete Cloud Scheduler job. Cloud Scheduler uses --location, not --region.
     # Earlier code passed --region which gcloud rejects, so cancel silently failed.
     scheduler_job_name = f"deployml-teardown-{workspace_name}"
-    result = subprocess.run(
-        ["gcloud", "scheduler", "jobs", "delete", scheduler_job_name,
-         "--project", project_id, "--location", region, "--quiet"],
+    result = run_tool(
+        "gcloud", ["scheduler", "jobs", "delete", scheduler_job_name,
+                   "--project", project_id, "--location", region, "--quiet"],
         capture_output=True,
         text=True,
     )
@@ -2033,9 +2033,9 @@ def show_teardown_status(config: dict, deployml_dir: Path, workspace_name: str):
     scheduler_job_name = f"deployml-teardown-{workspace_name}"
     
     # Query Cloud Scheduler job
-    result = subprocess.run(
-        ["gcloud", "scheduler", "jobs", "describe", scheduler_job_name,
-         "--project", project_id, "--location", region, "--format", "json"],
+    result = run_tool(
+        "gcloud", ["scheduler", "jobs", "describe", scheduler_job_name,
+                   "--project", project_id, "--location", region, "--format", "json"],
         capture_output=True,
         text=True,
     )
@@ -2130,9 +2130,9 @@ def update_teardown_schedule(config: dict, deployml_dir: Path, workspace_name: s
     scheduler_job_name = f"deployml-teardown-{workspace_name}"
     
     # Check if Cloud Scheduler job exists
-    result = subprocess.run(
-        ["gcloud", "scheduler", "jobs", "describe", scheduler_job_name,
-         "--project", project_id, "--location", region, "--format", "json"],
+    result = run_tool(
+        "gcloud", ["scheduler", "jobs", "describe", scheduler_job_name,
+                   "--project", project_id, "--location", region, "--format", "json"],
         capture_output=True,
         text=True,
     )
@@ -2182,9 +2182,10 @@ def update_teardown_schedule(config: dict, deployml_dir: Path, workspace_name: s
     # Update Cloud Scheduler job
     typer.echo("\n Updating Cloud Scheduler job...")
     typer.echo(f"   Cron schedule: {new_cron_schedule}")
-    update_result = subprocess.run(
+    update_result = run_tool(
+        "gcloud",
         [
-            "gcloud", "scheduler", "jobs", "update", "http", scheduler_job_name,
+            "scheduler", "jobs", "update", "http", scheduler_job_name,
             "--location", region,
             "--schedule", new_cron_schedule,
             "--time-zone", time_zone,
@@ -2202,9 +2203,9 @@ def update_teardown_schedule(config: dict, deployml_dir: Path, workspace_name: s
         raise typer.Exit(code=1)
     
     # Verify the update by querying the job again
-    verify_result = subprocess.run(
-        ["gcloud", "scheduler", "jobs", "describe", scheduler_job_name,
-         "--project", project_id, "--location", region, "--format", "json"],
+    verify_result = run_tool(
+        "gcloud", ["scheduler", "jobs", "describe", scheduler_job_name,
+                   "--project", project_id, "--location", region, "--format", "json"],
         capture_output=True,
         text=True,
     )
@@ -2310,9 +2311,9 @@ def init(
         typer.echo(
             f" Enabling required GCP APIs for project: {project_id} ..."
         )
-        result = subprocess.run(
+        result = run_tool(
+            "gcloud",
             [
-                "gcloud",
                 "services",
                 "enable",
                 *REQUIRED_GCP_APIS,
@@ -2654,7 +2655,7 @@ def gke_cluster_create(
         ]
     typer.echo(f" Creating {'Autopilot' if autopilot else 'standard'} cluster {cluster}...")
     typer.echo("   This typically takes 5 to 10 minutes.")
-    result = subprocess.run(cmd, capture_output=False, text=True)
+    result = run_tool(cmd[0], cmd[1:], capture_output=False, text=True)
     if result.returncode != 0:
         raise typer.Exit(code=1)
     typer.secho(f" Cluster {cluster} created.", fg=typer.colors.GREEN)
@@ -2722,8 +2723,8 @@ def gke_destroy(
         f = manifest_dir / fname
         if f.exists():
             typer.echo(f" Deleting {fname}...")
-            result = subprocess.run(
-                ["kubectl", "delete", "-f", str(f), "--ignore-not-found"] + ns,
+            result = run_tool(
+                "kubectl", ["delete", "-f", str(f), "--ignore-not-found"] + ns,
                 capture_output=True, text=True,
             )
             if result.returncode == 0:
@@ -2745,9 +2746,9 @@ def gke_destroy(
                 image = ""
         if image.startswith("gcr.io/"):
             typer.echo(f" Removing image {image}...")
-            subprocess.run(
-                ["gcloud", "container", "images", "delete", image,
-                 "--force-delete-tags", "--quiet", "--project", project],
+            run_tool(
+                "gcloud", ["container", "images", "delete", image,
+                           "--force-delete-tags", "--quiet", "--project", project],
                 capture_output=True,
             )
 
@@ -2765,7 +2766,7 @@ def gke_destroy(
         # billing. Retry until the in-flight operation clears.
         loc = zone or region
         for attempt in range(6):
-            result = subprocess.run(cmd, capture_output=True, text=True)
+            result = run_tool(cmd[0], cmd[1:], capture_output=True, text=True)
             if result.returncode == 0:
                 typer.echo(f" Cluster {cluster} deleted")
                 break

--- a/src/deployml/cli/cli.py
+++ b/src/deployml/cli/cli.py
@@ -46,7 +46,7 @@ from deployml.utils.helpers import (
     run_terraform_with_loading_bar,
     _create_docker_folder,
 )
-from deployml.utils.platform_compat import run_tool, resolve_tool
+from deployml.utils.platform_compat import run_tool, resolve_tool, configure_console_encoding
 from deployml.utils.infracost import (
     check_infracost_available,
     run_infracost_analysis,
@@ -3086,6 +3086,10 @@ def main():
     """
     Entry point for the DeployML CLI.
     """
+    # Force UTF-8 on the Windows console first so any emoji or box glyph in command
+    # output cannot raise UnicodeEncodeError on a legacy cp1252 console. No-op off
+    # Windows.
+    configure_console_encoding()
     cli()
 
 

--- a/src/deployml/cli/cli.py
+++ b/src/deployml/cli/cli.py
@@ -2709,10 +2709,31 @@ def gke_destroy(
         typer.echo("Either --zone or --region must be provided")
         raise typer.Exit(code=1)
 
-    from deployml.utils.kubernetes_gke import connect_to_gke_cluster
+    from deployml.utils.kubernetes_gke import (
+        connect_to_gke_cluster,
+        get_pvc_volume_handle,
+        disk_ref_from_volume_handle,
+        delete_gce_disk_if_exists,
+    )
 
     if not connect_to_gke_cluster(project, cluster, zone, region):
         raise typer.Exit(code=1)
+
+    # Capture the PVC's backing PersistentDisk BEFORE teardown. With
+    # --delete-cluster the in-cluster CSI driver can be removed before it finishes
+    # reclaiming the PD asynchronously, which orphans a billing disk (concern C12).
+    # We capture only the disk our own PVC created, then guarantee its removal
+    # after the cluster is gone.
+    pvc_disk_ref = None
+    if delete_cluster:
+        pvc_manifest = manifest_dir / "pvc.yaml"
+        if pvc_manifest.exists():
+            try:
+                pvc_name = yaml.safe_load(pvc_manifest.read_text())["metadata"]["name"]
+                handle = get_pvc_volume_handle(pvc_name, namespace)
+                pvc_disk_ref = disk_ref_from_volume_handle(handle) if handle else None
+            except Exception:
+                pvc_disk_ref = None
 
     # Delete in reverse order: service, then deployment, then PVC last. The PVC
     # is deleted explicitly because its backing PersistentDisk bills even after
@@ -2768,6 +2789,11 @@ def gke_destroy(
             result = run_tool(cmd[0], cmd[1:], capture_output=True, text=True)
             if result.returncode == 0:
                 typer.echo(f" Cluster {cluster} deleted")
+                # The cluster is gone, so the CSI driver can no longer reclaim the
+                # PVC's PersistentDisk. Guarantee that one disk is removed. No-op
+                # if the driver already reclaimed it before the cluster delete.
+                if pvc_disk_ref:
+                    delete_gce_disk_if_exists(project, pvc_disk_ref)
                 break
             if "incompatible operation" in (result.stderr or "").lower():
                 typer.echo("   Cluster busy with another operation, retrying in 20s...")

--- a/src/deployml/diagnostics/doctor.py
+++ b/src/deployml/diagnostics/doctor.py
@@ -1,4 +1,3 @@
-import subprocess
 import shutil
 import os
 import sys
@@ -7,6 +6,9 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 import json
 import importlib
+
+from deployml.utils.platform_compat import run_tool
+
 try:
     from importlib.metadata import version as get_package_version_metadata
 except ImportError:
@@ -216,7 +218,7 @@ class DeployMLDoctor:
             return
         
         try:
-            result = subprocess.run(['docker', '--version'], capture_output=True, text=True)
+            result = run_tool('docker', ['--version'], capture_output=True, text=True)
             if result.returncode == 0:
                 version = result.stdout.strip()
                 self._add_result(CheckResult(
@@ -251,7 +253,7 @@ class DeployMLDoctor:
             return
         
         try:
-            result = subprocess.run(['terraform', 'version'], capture_output=True, text=True)
+            result = run_tool('terraform', ['version'], capture_output=True, text=True)
             if result.returncode == 0:
                 version_line = result.stdout.split('\n')[0]
                 self._add_result(CheckResult(
@@ -286,7 +288,7 @@ class DeployMLDoctor:
             if shutil.which(tool):
                 try:
                     if tool == 'gcloud':
-                        result = subprocess.run(['gcloud', 'version'], capture_output=True, text=True)
+                        result = run_tool('gcloud', ['version'], capture_output=True, text=True)
                         if result.returncode == 0:
                             version = result.stdout.split('\n')[0]
                             self._add_result(CheckResult(
@@ -304,7 +306,7 @@ class DeployMLDoctor:
                             ))
                     else:
                         # For AWS and Azure CLI
-                        result = subprocess.run([tool, '--version'], capture_output=True, text=True)
+                        result = run_tool(tool, ['--version'], capture_output=True, text=True)
                         if result.returncode == 0:
                             version = result.stdout.strip()
                             self._add_result(CheckResult(
@@ -342,7 +344,7 @@ class DeployMLDoctor:
             return
         
         try:
-            result = subprocess.run(['git', '--version'], capture_output=True, text=True)
+            result = run_tool('git', ['--version'], capture_output=True, text=True)
             if result.returncode == 0:
                 version = result.stdout.strip()
                 self._add_result(CheckResult(
@@ -372,7 +374,7 @@ class DeployMLDoctor:
             return
         
         try:
-            result = subprocess.run(['infracost', '--version'], capture_output=True, text=True)
+            result = run_tool('infracost', ['--version'], capture_output=True, text=True)
             if result.returncode == 0:
                 version = result.stdout.strip()
                 self._add_result(CheckResult(
@@ -392,7 +394,7 @@ class DeployMLDoctor:
     def _check_docker_permissions(self):
         """Check Docker permissions"""
         try:
-            result = subprocess.run(['docker', 'ps'], capture_output=True, text=True)
+            result = run_tool('docker', ['ps'], capture_output=True, text=True)
             if result.returncode == 0:
                 self._add_result(CheckResult(
                     name="Docker Permissions",
@@ -427,7 +429,7 @@ class DeployMLDoctor:
         # Check GCP authentication
         if shutil.which('gcloud'):
             try:
-                result = subprocess.run(['gcloud', 'auth', 'list'], capture_output=True, text=True)
+                result = run_tool('gcloud', ['auth', 'list'], capture_output=True, text=True)
                 if result.returncode == 0 and "ACTIVE" in result.stdout:
                     self._add_result(CheckResult(
                         name="GCP Authentication",

--- a/src/deployml/diagnostics/doctor.py
+++ b/src/deployml/diagnostics/doctor.py
@@ -393,6 +393,17 @@ class DeployMLDoctor:
     
     def _check_docker_permissions(self):
         """Check Docker permissions"""
+        if not shutil.which('docker'):
+            # _check_docker already reports the missing binary. Skip here rather
+            # than emit a misleading "cannot run docker" permission failure.
+            self._add_result(CheckResult(
+                name="Docker Permissions",
+                status=CheckStatus.SKIP,
+                message="Docker not installed, skipping permission check",
+                required=False
+            ))
+            return
+
         try:
             result = run_tool('docker', ['ps'], capture_output=True, text=True)
             if result.returncode == 0:

--- a/src/deployml/notebook/docker.py
+++ b/src/deployml/notebook/docker.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Optional
 
 from deployml.utils.helpers import check_docker_daemon
+from deployml.utils.platform_compat import run_tool
 
 class ImageBuildError(Exception):
     pass
@@ -94,8 +95,8 @@ def build_images(
                 print()
             else:
                 print("Ensuring Artifact Registry repository exists...")
-                create_proc = subprocess.run(
-                    create_cmd, check=False,
+                create_proc = run_tool(
+                    create_cmd[0], create_cmd[1:], check=False,
                     capture_output=True, text=True,
                 )
                 stderr_lower = (create_proc.stderr or "").lower()
@@ -127,7 +128,7 @@ def build_images(
                 print()
             else:
                 print(f"Building {service_name} via Cloud Build...")
-                subprocess.run(build_cmd, check=True)
+                run_tool(build_cmd[0], build_cmd[1:], check=True)
                 print(f"Pushed: {image_uri}")
                 print()
 
@@ -155,7 +156,7 @@ def build_images(
                 print()
             else:
                 print(f"Building {service_name} locally...")
-                subprocess.run(build_cmd, check=True)
+                run_tool(build_cmd[0], build_cmd[1:], check=True)
                 print(f"Built: {image_name}")
                 print()
 
@@ -168,8 +169,8 @@ def build_images(
 
 def _validate_docker():
     try:
-        subprocess.run(
-            ["docker", "--version"],
+        run_tool(
+            "docker", ["--version"],
             check=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -187,9 +188,9 @@ def _build_locally(service_dirs: list[Path], tag: str):
 
         print(f"Building {image_name} ...")
 
-        subprocess.run(
+        run_tool(
+            "docker",
             [
-                "docker",
                 "build",
                 "-t",
                 image_name,
@@ -207,8 +208,8 @@ def _build_locally(service_dirs: list[Path], tag: str):
 
 def _validate_gcloud():
     try:
-        subprocess.run(
-            ["gcloud", "--version"],
+        run_tool(
+            "gcloud", ["--version"],
             check=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -238,9 +239,9 @@ def _build_with_cloud_build(
 
         print(f"Submitting Cloud Build for {image_uri} ...")
 
-        subprocess.run(
+        run_tool(
+            "gcloud",
             [
-                "gcloud",
                 "builds",
                 "submit",
                 str(service_dir),

--- a/src/deployml/notebook/stack.py
+++ b/src/deployml/notebook/stack.py
@@ -1,5 +1,4 @@
 import json
-import subprocess
 from pathlib import Path
 from typing import Dict, Any, TYPE_CHECKING
 from datetime import datetime, timezone
@@ -10,6 +9,7 @@ if TYPE_CHECKING:
 
 from .urls import ServiceURLs
 from .display import display_services_table
+from deployml.utils.platform_compat import run_tool
 
 
 class DeploymentStack:
@@ -37,8 +37,8 @@ class DeploymentStack:
         """Extract URLs from Terraform outputs"""
         try:
             terraform_dir = self.workspace_dir / "terraform"
-            result = subprocess.run(
-                ["terraform", "output", "-json"],
+            result = run_tool(
+                "terraform", ["output", "-json"],
                 cwd=terraform_dir,
                 capture_output=True,
                 text=True,
@@ -130,8 +130,8 @@ class DeploymentStack:
         """
         try:
             terraform_dir = self.workspace_dir / "terraform"
-            result = subprocess.run(
-                ["terraform", "output", "-json"],
+            result = run_tool(
+                "terraform", ["output", "-json"],
                 cwd=terraform_dir,
                 capture_output=True,
                 text=True,
@@ -149,8 +149,8 @@ class DeploymentStack:
                     if show_credentials:
                         # Try to get the actual sensitive value
                         try:
-                            sensitive_result = subprocess.run(
-                                ["terraform", "output", "-raw", key],
+                            sensitive_result = run_tool(
+                                "terraform", ["output", "-raw", key],
                                 cwd=terraform_dir,
                                 capture_output=True,
                                 text=True,
@@ -326,8 +326,8 @@ class DeploymentStack:
         """Get detailed cron job information"""
         try:
             terraform_dir = self.workspace_dir / "terraform"
-            result = subprocess.run(
-                ["terraform", "output", "-json"],
+            result = run_tool(
+                "terraform", ["output", "-json"],
                 cwd=terraform_dir,
                 capture_output=True,
                 text=True,

--- a/src/deployml/terraform/modules/cloud_sql_postgres/main.tf
+++ b/src/deployml/terraform/modules/cloud_sql_postgres/main.tf
@@ -36,7 +36,15 @@ resource "null_resource" "verify_instance_running" {
   depends_on = [google_sql_database_instance.postgres]
   
   provisioner "local-exec" {
-    command = <<-EOT
+    # Run under bash explicitly. This script uses bash only syntax, set +e, brace
+    # expansion {1..30}, command -v, POSIX test brackets, sleep. On Windows the
+    # default local-exec shell is cmd.exe, which cannot parse any of it, so the
+    # provisioner would fail. bash is provided by Git for Windows or WSL. This is
+    # also a portability win on Ubuntu, where /bin/sh is dash and does not expand
+    # {1..30}. The script self-guards with command -v gcloud and always exits 0, so
+    # it degrades gracefully and never fails the deploy regardless of which bash.
+    interpreter = ["bash", "-c"]
+    command     = <<-EOT
       set +e
       echo "Checking Cloud SQL instance status..."
       if ! command -v gcloud &> /dev/null; then

--- a/src/deployml/utils/helpers.py
+++ b/src/deployml/utils/helpers.py
@@ -9,7 +9,6 @@ import random
 import string
 from deployml.utils.constants import ANIMAL_NAMES, FALLBACK_WORDS, TERRAFORM_DIR
 from deployml.utils.platform_compat import run_tool, resolve_tool, terraform_env
-import subprocess
 import time
 from rich.progress import (
     Progress,
@@ -435,8 +434,6 @@ def cleanup_terraform_files(terraform_dir: Path):
     """
     Clean up Terraform state and lock files from the specified directory.
     """
-    import shutil
-
     cleanup_files = [
         ".terraform",
         "terraform.tfstate",

--- a/src/deployml/utils/helpers.py
+++ b/src/deployml/utils/helpers.py
@@ -505,9 +505,10 @@ def run_terraform_with_loading_bar(cmd, cwd, estimated_minutes, stack=None, verb
     log_file = cwd / "terraform_apply.log"
 
     if verbose:
-        with open(log_file, "w") as f:
+        with open(log_file, "w", encoding="utf-8", errors="replace") as f:
             process = subprocess.Popen(
                 cmd, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+                encoding="utf-8", errors="replace",
                 env=tf_env,
             )
             for line in iter(process.stdout.readline, ""):
@@ -526,7 +527,7 @@ def run_terraform_with_loading_bar(cmd, cwd, estimated_minutes, stack=None, verb
         task = progress.add_task(resource_msgs[0], total=100)
 
         # Open log file and keep it open until process completes
-        f = open(log_file, "w")
+        f = open(log_file, "w", encoding="utf-8", errors="replace")
         try:
             process = subprocess.Popen(
                 cmd, cwd=cwd, stdout=f, stderr=subprocess.STDOUT, env=tf_env

--- a/src/deployml/utils/helpers.py
+++ b/src/deployml/utils/helpers.py
@@ -8,6 +8,7 @@ from google.cloud import storage
 import random
 import string
 from deployml.utils.constants import ANIMAL_NAMES, FALLBACK_WORDS, TERRAFORM_DIR
+from deployml.utils.platform_compat import run_tool, resolve_tool
 import subprocess
 import time
 from rich.progress import (
@@ -47,8 +48,8 @@ def check_gcp_auth() -> bool:
         bool: True if authenticated, False otherwise.
     """
     try:
-        result = subprocess.run(
-            ["gcloud", "auth", "list"], capture_output=True, text=True
+        result = run_tool(
+            "gcloud", ["auth", "list"], capture_output=True, text=True
         )
         return "ACTIVE" in result.stdout
     except Exception:
@@ -58,8 +59,8 @@ def check_gcp_auth() -> bool:
 def check_gcp_adc() -> bool:
     """Application Default Credentials are required by Terraform and client libs."""
     try:
-        result = subprocess.run(
-            ["gcloud", "auth", "application-default", "print-access-token"],
+        result = run_tool(
+            "gcloud", ["auth", "application-default", "print-access-token"],
             capture_output=True, text=True,
         )
         return result.returncode == 0
@@ -71,8 +72,8 @@ def check_bq() -> bool:
     if not shutil.which("bq"):
         return False
     try:
-        result = subprocess.run(
-            ["bq", "version"], capture_output=True, text=True,
+        result = run_tool(
+            "bq", ["version"], capture_output=True, text=True,
         )
         return result.returncode == 0
     except Exception:
@@ -85,8 +86,8 @@ def get_terraform_version() -> Optional[tuple]:
         return None
     try:
         import json as _json
-        result = subprocess.run(
-            ["terraform", "version", "-json"],
+        result = run_tool(
+            "terraform", ["version", "-json"],
             capture_output=True, text=True,
         )
         if result.returncode != 0:
@@ -101,9 +102,9 @@ def get_terraform_version() -> Optional[tuple]:
 def validate_gcp_project(project_id: str) -> bool:
     """Verify project exists and active gcloud account can access it."""
     try:
-        result = subprocess.run(
-            ["gcloud", "projects", "describe", project_id,
-             "--format=value(projectId)"],
+        result = run_tool(
+            "gcloud", ["projects", "describe", project_id,
+                       "--format=value(projectId)"],
             capture_output=True, text=True,
         )
         return result.returncode == 0 and result.stdout.strip() == project_id
@@ -122,7 +123,7 @@ def validate_gcp_region(region: str, project_id: Optional[str] = None) -> bool:
         if project_id:
             cmd += ["--project", project_id]
         try:
-            result = subprocess.run(cmd, capture_output=True, text=True)
+            result = run_tool(cmd[0], cmd[1:], capture_output=True, text=True)
             if result.returncode != 0:
                 print(
                     f"Warning: could not verify region '{region}' "
@@ -146,16 +147,16 @@ def get_missing_iam_roles(project_id: str, required_roles: list) -> list:
     """Return roles the active account lacks. roles/owner short-circuits to empty."""
     try:
         import json as _json
-        account_result = subprocess.run(
-            ["gcloud", "config", "get-value", "account"],
+        account_result = run_tool(
+            "gcloud", ["config", "get-value", "account"],
             capture_output=True, text=True,
         )
         account = account_result.stdout.strip()
         if not account:
             return list(required_roles)
 
-        result = subprocess.run(
-            ["gcloud", "projects", "get-iam-policy", project_id, "--format=json"],
+        result = run_tool(
+            "gcloud", ["projects", "get-iam-policy", project_id, "--format=json"],
             capture_output=True, text=True,
         )
         if result.returncode != 0:
@@ -180,8 +181,8 @@ def check_docker_daemon() -> bool:
     if not shutil.which("docker"):
         return False
     try:
-        result = subprocess.run(
-            ["docker", "info"], capture_output=True, text=True,
+        result = run_tool(
+            "docker", ["info"], capture_output=True, text=True,
         )
         return result.returncode == 0
     except Exception:
@@ -399,12 +400,11 @@ def cleanup_cloud_sql_resources(terraform_dir: Path, project_id: str):
     delete databases and users. We just restart the instance — that kills all
     active connections — and let Terraform handle the actual resource deletion.
     """
-    import subprocess
     import time as _time
 
     try:
-        result = subprocess.run(
-            ["terraform", "output", "-raw", "instance_connection_name"],
+        result = run_tool(
+            "terraform", ["output", "-raw", "instance_connection_name"],
             cwd=terraform_dir,
             capture_output=True,
             text=True,
@@ -417,9 +417,9 @@ def cleanup_cloud_sql_resources(terraform_dir: Path, project_id: str):
         instance_name = parts[2] if len(parts) == 3 else instance_connection_name
 
         print(f"🗄️  Restarting Cloud SQL instance to close active connections: {instance_name}")
-        subprocess.run(
-            ["gcloud", "sql", "instances", "restart", instance_name,
-             "--project", project_id, "--quiet"],
+        run_tool(
+            "gcloud", ["sql", "instances", "restart", instance_name,
+                       "--project", project_id, "--quiet"],
             capture_output=True,
             text=True,
         )
@@ -468,6 +468,11 @@ def run_terraform_with_loading_bar(cmd, cwd, estimated_minutes, stack=None, verb
     Returns:
         int: The return code of the process.
     """
+    # Resolve the tool to its real path so the streaming Popen calls below work on
+    # Windows, where a bare .cmd name would fail. terraform is a real .exe, but
+    # resolving keeps this robust if the front tool ever changes.
+    cmd = [resolve_tool(cmd[0]), *cmd[1:]]
+
     # Default messages if stack is not provided
     default_msgs = [
         "DeployML: Preparing your cloud environment...",

--- a/src/deployml/utils/helpers.py
+++ b/src/deployml/utils/helpers.py
@@ -8,7 +8,7 @@ from google.cloud import storage
 import random
 import string
 from deployml.utils.constants import ANIMAL_NAMES, FALLBACK_WORDS, TERRAFORM_DIR
-from deployml.utils.platform_compat import run_tool, resolve_tool
+from deployml.utils.platform_compat import run_tool, resolve_tool, terraform_env
 import subprocess
 import time
 from rich.progress import (
@@ -473,6 +473,12 @@ def run_terraform_with_loading_bar(cmd, cwd, estimated_minutes, stack=None, verb
     # resolving keeps this robust if the front tool ever changes.
     cmd = [resolve_tool(cmd[0]), *cmd[1:]]
 
+    # On Windows, ensure terraform's local-exec bash interpreter resolves to Git
+    # bash, not the WSL launcher in System32 which mangles quoting and breaks the
+    # Cloud SQL readiness provisioner. None off Windows, so behavior is unchanged
+    # on macOS and Linux.
+    tf_env = terraform_env()
+
     # Default messages if stack is not provided
     default_msgs = [
         "DeployML: Preparing your cloud environment...",
@@ -501,7 +507,8 @@ def run_terraform_with_loading_bar(cmd, cwd, estimated_minutes, stack=None, verb
     if verbose:
         with open(log_file, "w") as f:
             process = subprocess.Popen(
-                cmd, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
+                cmd, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+                env=tf_env,
             )
             for line in iter(process.stdout.readline, ""):
                 print(line, end="", flush=True)
@@ -522,7 +529,7 @@ def run_terraform_with_loading_bar(cmd, cwd, estimated_minutes, stack=None, verb
         f = open(log_file, "w")
         try:
             process = subprocess.Popen(
-                cmd, cwd=cwd, stdout=f, stderr=subprocess.STDOUT
+                cmd, cwd=cwd, stdout=f, stderr=subprocess.STDOUT, env=tf_env
             )
             start_time = time.time()
             estimated_seconds = estimated_minutes * 60

--- a/src/deployml/utils/infracost.py
+++ b/src/deployml/utils/infracost.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from typing import Dict, Optional, List
 from dataclasses import dataclass
 
+from deployml.utils.platform_compat import run_tool
+
 
 @dataclass
 class CostComponent:
@@ -48,8 +50,8 @@ def check_infracost_available() -> bool:
         bool: True if infracost is available, False otherwise.
     """
     try:
-        result = subprocess.run(
-            ["infracost", "--version"],
+        result = run_tool(
+            "infracost", ["--version"],
             capture_output=True,
             text=True,
             timeout=10,
@@ -89,8 +91,8 @@ def run_infracost_breakdown(terraform_dir: Path, usage_file: Optional[Path] = No
         if usage_file is not None:
             cmd.extend(["--usage-file", str(usage_file)])
 
-        result = subprocess.run(
-            cmd,
+        result = run_tool(
+            cmd[0], cmd[1:],
             cwd=terraform_dir,
             capture_output=True,
             text=True,

--- a/src/deployml/utils/kubernetes_gke.py
+++ b/src/deployml/utils/kubernetes_gke.py
@@ -12,6 +12,7 @@ except Exception:
 
 from deployml.utils.constants import TEMPLATE_DIR
 from deployml.utils.kubernetes_local import ensure_namespace, ns_args
+from deployml.utils.platform_compat import run_tool
 
 
 def check_gke_cluster_connection(cluster_name: str, zone: Optional[str] = None, region: Optional[str] = None) -> bool:
@@ -22,14 +23,14 @@ def check_gke_cluster_connection(cluster_name: str, zone: Optional[str] = None, 
     only return True if the current context contains the exact cluster name.
     """
     try:
-        result = subprocess.run(
-            ["kubectl", "cluster-info"],
+        result = run_tool(
+            "kubectl", ["cluster-info"],
             capture_output=True,
             text=True
         )
         if result.returncode == 0:
-            context_result = subprocess.run(
-                ["kubectl", "config", "current-context"],
+            context_result = run_tool(
+                "kubectl", ["config", "current-context"],
                 capture_output=True,
                 text=True
             )
@@ -67,8 +68,8 @@ def connect_to_gke_cluster(
             typer.echo("Either zone or region must be provided")
             return False
         
-        result = subprocess.run(
-            cmd,
+        result = run_tool(
+            cmd[0], cmd[1:],
             check=True,
             capture_output=True,
             text=True
@@ -89,16 +90,16 @@ def push_image_to_gcr(image_name: str, gcr_image: str, project_id: str) -> bool:
     
     try:
         # Tag image
-        tag_result = subprocess.run(
-            ["docker", "tag", image_name, gcr_image],
+        tag_result = run_tool(
+            "docker", ["tag", image_name, gcr_image],
             check=True,
             capture_output=True,
             text=True
         )
-        
+
         # Push image
-        push_result = subprocess.run(
-            ["docker", "push", gcr_image],
+        push_result = run_tool(
+            "docker", ["push", gcr_image],
             check=True,
             capture_output=True,
             text=True
@@ -366,8 +367,8 @@ def deploy_to_gke(
         pvc_file = manifest_dir / "pvc.yaml"
         if pvc_file.exists():
             typer.echo(f"   Applying {pvc_file.name}...")
-            result = subprocess.run(
-                ["kubectl", "apply", "-f", str(pvc_file)] + ns,
+            result = run_tool(
+                "kubectl", ["apply", "-f", str(pvc_file)] + ns,
                 check=True,
                 capture_output=True,
                 text=True
@@ -375,8 +376,8 @@ def deploy_to_gke(
             typer.echo(f"   {result.stdout.strip()}")
 
         typer.echo(f"   Applying {deployment_file.name}...")
-        result = subprocess.run(
-            ["kubectl", "apply", "-f", str(deployment_file)] + ns,
+        result = run_tool(
+            "kubectl", ["apply", "-f", str(deployment_file)] + ns,
             check=True,
             capture_output=True,
             text=True
@@ -384,8 +385,8 @@ def deploy_to_gke(
         typer.echo(f"   {result.stdout.strip()}")
 
         typer.echo(f"   Applying {service_file.name}...")
-        result = subprocess.run(
-            ["kubectl", "apply", "-f", str(service_file)] + ns,
+        result = run_tool(
+            "kubectl", ["apply", "-f", str(service_file)] + ns,
             check=True,
             capture_output=True,
             text=True
@@ -420,14 +421,14 @@ def deploy_to_gke(
             ip_query = "{.status.loadBalancer.ingress[0].ip}"
             cmd = ["kubectl", "get", "svc", service_name,
                    "-o", f"jsonpath={ip_query}"] + ns
-            result = subprocess.run(cmd, capture_output=True, text=True)
+            result = run_tool(cmd[0], cmd[1:], capture_output=True, text=True)
 
             external_ip = result.stdout.strip().strip("'")
             if result.returncode == 0 and external_ip and external_ip != "<none>":
                 port_query = "{.spec.ports[0].port}"
                 port_cmd = ["kubectl", "get", "svc", service_name,
                             "-o", f"jsonpath={port_query}"] + ns
-                port_result = subprocess.run(port_cmd, capture_output=True, text=True)
+                port_result = run_tool(port_cmd[0], port_cmd[1:], capture_output=True, text=True)
                 port = port_result.stdout.strip().strip("'") or "5000"
                 typer.echo(f"\n Service is available at: http://{external_ip}:{port}")
                 break
@@ -438,8 +439,8 @@ def deploy_to_gke(
                 typer.echo(f"   Still waiting... ({waited}s)")
         
         typer.echo("\n Deployment status:")
-        subprocess.run(["kubectl", "get", "pods"] + ns)
-        subprocess.run(["kubectl", "get", "svc"] + ns)
+        run_tool("kubectl", ["get", "pods"] + ns)
+        run_tool("kubectl", ["get", "svc"] + ns)
 
         return True
         

--- a/src/deployml/utils/kubernetes_gke.py
+++ b/src/deployml/utils/kubernetes_gke.py
@@ -247,8 +247,13 @@ def generate_fastapi_manifests_gke(
     # avoid the :latest drift bug that bites the Cloud Run path the same way.
     if not image.startswith("gcr.io/"):
         gcr_image = f"gcr.io/{project_id}/fastapi/fastapi:v{_DEPLOYML_VERSION}"
-        if push_image:
-            push_image_to_gcr(image, gcr_image, project_id)
+        if push_image and not push_image_to_gcr(image, gcr_image, project_id):
+            typer.echo(
+                f"WARNING: could not push the image to {gcr_image}. The manifest "
+                f"references that image, so the GKE deploy will fail with "
+                f"ImagePullBackOff until it exists. Start Docker and retry, or push "
+                f"the image to {gcr_image} yourself, then deploy."
+            )
         image = gcr_image
     else:
         gcr_image = image
@@ -344,8 +349,13 @@ def generate_mlflow_manifests_gke(
     # Convert local image to GCR format. Pin tag to the deployml version.
     if not image.startswith("gcr.io/"):
         gcr_image = f"gcr.io/{project_id}/mlflow/mlflow:v{_DEPLOYML_VERSION}"
-        if push_image:
-            push_image_to_gcr(image, gcr_image, project_id)
+        if push_image and not push_image_to_gcr(image, gcr_image, project_id):
+            typer.echo(
+                f"WARNING: could not push the image to {gcr_image}. The manifest "
+                f"references that image, so the GKE deploy will fail with "
+                f"ImagePullBackOff until it exists. Start Docker and retry, or push "
+                f"the image to {gcr_image} yourself, then deploy."
+            )
         image = gcr_image
     else:
         gcr_image = image

--- a/src/deployml/utils/kubernetes_gke.py
+++ b/src/deployml/utils/kubernetes_gke.py
@@ -1,3 +1,5 @@
+import os
+import shutil
 import subprocess
 import typer
 from pathlib import Path
@@ -40,6 +42,27 @@ def check_gke_cluster_connection(cluster_name: str, zone: Optional[str] = None, 
         return False
 
 
+def warn_if_gke_auth_plugin_missing() -> None:
+    """kubectl needs gke-gcloud-auth-plugin to authenticate to GKE. The gcloud SDK
+    installs it into the SDK bin directory, which is not always on the PATH that a
+    subprocess inherits, especially on Windows. Warn with an actionable hint up
+    front instead of letting kubectl fail later with a cryptic
+    "executable gke-gcloud-auth-plugin not found"."""
+    if shutil.which("gke-gcloud-auth-plugin"):
+        return
+    typer.echo(
+        "WARNING: gke-gcloud-auth-plugin was not found on PATH. kubectl cannot "
+        "authenticate to GKE without it."
+    )
+    typer.echo("   Install it: gcloud components install gke-gcloud-auth-plugin")
+    if os.name == "nt":
+        typer.echo(
+            "   Then add the gcloud SDK bin directory to PATH, typically "
+            "%LOCALAPPDATA%\\Google\\Cloud SDK\\google-cloud-sdk\\bin or "
+            "C:\\Program Files (x86)\\Google\\Cloud SDK\\google-cloud-sdk\\bin."
+        )
+
+
 def connect_to_gke_cluster(
     project_id: str,
     cluster_name: str,
@@ -75,6 +98,8 @@ def connect_to_gke_cluster(
             text=True
         )
         typer.echo(f"Connected to cluster: {cluster_name}")
+        # kubectl will now need the GKE auth plugin; warn early if it is missing.
+        warn_if_gke_auth_plugin_missing()
         return True
     except subprocess.CalledProcessError as e:
         typer.echo(f"Failed to connect to cluster: {e.stderr}")

--- a/src/deployml/utils/kubernetes_gke.py
+++ b/src/deployml/utils/kubernetes_gke.py
@@ -63,6 +63,88 @@ def warn_if_gke_auth_plugin_missing() -> None:
         )
 
 
+def disk_ref_from_volume_handle(volume_handle):
+    """Parse a GCE PD CSI volume handle into (disk_name, location_flag, location).
+
+    Handles zonal "projects/P/zones/Z/disks/NAME" and regional
+    "projects/P/regions/R/disks/NAME" forms. Returns None when the string is not a
+    GCE PD handle, so callers can skip cleanup safely.
+    """
+    if not volume_handle:
+        return None
+    parts = volume_handle.strip().strip("/").split("/")
+    if "disks" not in parts:
+        return None
+    di = parts.index("disks")
+    if di + 1 >= len(parts):
+        return None
+    disk_name = parts[di + 1]
+    if "zones" in parts:
+        return (disk_name, "--zone", parts[parts.index("zones") + 1])
+    if "regions" in parts:
+        return (disk_name, "--region", parts[parts.index("regions") + 1])
+    return None
+
+
+def get_pvc_volume_handle(pvc_name, namespace=None):
+    """Return the CSI volume handle of the PV bound to pvc_name, or None.
+
+    Must be called while the PVC still exists, since it follows the PVC to its
+    bound PV and reads the PV's CSI volume handle. Used by gke-destroy to capture
+    the backing PersistentDisk before teardown.
+    """
+    ns = ["-n", namespace] if namespace and namespace != "default" else []
+    pv = run_tool(
+        "kubectl",
+        ["get", "pvc", pvc_name, "-o", "jsonpath={.spec.volumeName}"] + ns,
+        capture_output=True, text=True,
+    )
+    pv_name = (pv.stdout or "").strip()
+    if pv.returncode != 0 or not pv_name:
+        return None
+    handle = run_tool(
+        "kubectl",
+        ["get", "pv", pv_name, "-o", "jsonpath={.spec.csi.volumeHandle}"],
+        capture_output=True, text=True,
+    )
+    vh = (handle.stdout or "").strip()
+    return vh or None
+
+
+def delete_gce_disk_if_exists(project, disk_ref) -> bool:
+    """Best-effort delete of a specific GCE PersistentDisk.
+
+    disk_ref is (disk_name, location_flag, location) as returned by
+    disk_ref_from_volume_handle. If the disk is already gone, for example the CSI
+    driver reclaimed it before the cluster was deleted, describe fails and no
+    delete is issued. Only ever touches the one disk passed in, so it cannot
+    affect unrelated disks. Returns True if the disk is absent afterward.
+    """
+    disk_name, loc_flag, loc = disk_ref
+    describe = run_tool(
+        "gcloud",
+        ["compute", "disks", "describe", disk_name, loc_flag, loc,
+         "--project", project, "--format=value(name)"],
+        capture_output=True, text=True,
+    )
+    if describe.returncode != 0:
+        return True
+    typer.echo(f" Removing orphaned persistent disk {disk_name}...")
+    run_tool(
+        "gcloud",
+        ["compute", "disks", "delete", disk_name, loc_flag, loc,
+         "--project", project, "--quiet"],
+        capture_output=True, text=True,
+    )
+    verify = run_tool(
+        "gcloud",
+        ["compute", "disks", "describe", disk_name, loc_flag, loc,
+         "--project", project, "--format=value(name)"],
+        capture_output=True, text=True,
+    )
+    return verify.returncode != 0
+
+
 def connect_to_gke_cluster(
     project_id: str,
     cluster_name: str,

--- a/src/deployml/utils/kubernetes_local.py
+++ b/src/deployml/utils/kubernetes_local.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Optional, Dict
 from jinja2 import Environment, FileSystemLoader
 from deployml.utils.constants import TEMPLATE_DIR
+from deployml.utils.platform_compat import run_tool
 
 
 def ns_args(namespace: Optional[str]) -> list:
@@ -17,21 +18,21 @@ def ensure_namespace(namespace: Optional[str]) -> None:
     namespace. Idempotent via apply of a client-side dry-run manifest."""
     if not namespace or namespace == "default":
         return
-    rendered = subprocess.run(
-        ["kubectl", "create", "namespace", namespace, "--dry-run=client", "-o", "yaml"],
+    rendered = run_tool(
+        "kubectl", ["create", "namespace", namespace, "--dry-run=client", "-o", "yaml"],
         capture_output=True, text=True,
     )
     if rendered.returncode == 0:
-        subprocess.run(["kubectl", "apply", "-f", "-"], input=rendered.stdout,
-                       capture_output=True, text=True)
+        run_tool("kubectl", ["apply", "-f", "-"], input=rendered.stdout,
+                 capture_output=True, text=True)
         typer.echo(f"   Using namespace: {namespace}")
 
 
 def check_minikube_running() -> bool:
     """Check if minikube is currently running."""
     try:
-        result = subprocess.run(
-            ["minikube", "status"],
+        result = run_tool(
+            "minikube", ["status"],
             capture_output=True,
             text=True
         )
@@ -44,8 +45,8 @@ def start_minikube() -> bool:
     """Start minikube cluster."""
     typer.echo("Starting minikube...")
     try:
-        result = subprocess.run(
-            ["minikube", "start"],
+        result = run_tool(
+            "minikube", ["start"],
             check=True,
             capture_output=True,
             text=True
@@ -264,15 +265,15 @@ def deploy_mlflow_to_minikube(manifest_dir: Path, image_name: Optional[str] = No
         pvc_file = manifest_dir / "pvc.yaml"
         if pvc_file.exists():
             typer.echo(f"   Applying {pvc_file.name}...")
-            result = subprocess.run(
-                ["kubectl", "apply", "-f", str(pvc_file)] + ns,
+            result = run_tool(
+                "kubectl", ["apply", "-f", str(pvc_file)] + ns,
                 check=True, capture_output=True, text=True,
             )
             typer.echo(f"{result.stdout.strip()}")
 
         typer.echo(f"   Applying {deployment_file.name}...")
-        result = subprocess.run(
-            ["kubectl", "apply", "-f", str(deployment_file)] + ns,
+        result = run_tool(
+            "kubectl", ["apply", "-f", str(deployment_file)] + ns,
             check=True,
             capture_output=True,
             text=True
@@ -281,8 +282,8 @@ def deploy_mlflow_to_minikube(manifest_dir: Path, image_name: Optional[str] = No
 
         # Apply service
         typer.echo(f"   Applying {service_file.name}...")
-        result = subprocess.run(
-            ["kubectl", "apply", "-f", str(service_file)] + ns,
+        result = run_tool(
+            "kubectl", ["apply", "-f", str(service_file)] + ns,
             check=True,
             capture_output=True,
             text=True
@@ -294,8 +295,8 @@ def deploy_mlflow_to_minikube(manifest_dir: Path, image_name: Optional[str] = No
 
         # Try minikube service --url with timeout (can hang)
         try:
-            result = subprocess.run(
-                ["minikube", "service", "mlflow-service", "--url"] + ns,
+            result = run_tool(
+                "minikube", ["service", "mlflow-service", "--url"] + ns,
                 capture_output=True,
                 text=True,
                 timeout=5  # 5 second timeout to prevent hanging
@@ -309,15 +310,15 @@ def deploy_mlflow_to_minikube(manifest_dir: Path, image_name: Optional[str] = No
         except (subprocess.TimeoutExpired, subprocess.CalledProcessError):
             # Fallback: get NodePort manually (more reliable)
             typer.echo("   Getting NodePort...")
-            result = subprocess.run(
-                ["kubectl", "get", "svc", "mlflow-service", "-o", "jsonpath='{.spec.ports[0].nodePort}'"] + ns,
+            result = run_tool(
+                "kubectl", ["get", "svc", "mlflow-service", "-o", "jsonpath='{.spec.ports[0].nodePort}'"] + ns,
                 capture_output=True,
                 text=True
             )
             if result.returncode == 0:
                 node_port = result.stdout.strip().strip("'")
-                minikube_ip_result = subprocess.run(
-                    ["minikube", "ip"],
+                minikube_ip_result = run_tool(
+                    "minikube", ["ip"],
                     capture_output=True,
                     text=True
                 )
@@ -330,8 +331,8 @@ def deploy_mlflow_to_minikube(manifest_dir: Path, image_name: Optional[str] = No
                 typer.echo("   Could not determine service URL. Check with: kubectl get svc mlflow-service")
 
         typer.echo("\n Deployment status:")
-        subprocess.run(["kubectl", "get", "pods", "-l", "app=mlflow"] + ns)
-        subprocess.run(["kubectl", "get", "svc", "-l", "app=mlflow"] + ns)
+        run_tool("kubectl", ["get", "pods", "-l", "app=mlflow"] + ns)
+        run_tool("kubectl", ["get", "svc", "-l", "app=mlflow"] + ns)
         
         return True
         
@@ -387,8 +388,8 @@ def deploy_fastapi_to_minikube(manifest_dir: Path, image_name: Optional[str] = N
 
     try:
         typer.echo(f"   Applying {deployment_file.name}...")
-        result = subprocess.run(
-            ["kubectl", "apply", "-f", str(deployment_file)] + ns,
+        result = run_tool(
+            "kubectl", ["apply", "-f", str(deployment_file)] + ns,
             check=True,
             capture_output=True,
             text=True
@@ -397,8 +398,8 @@ def deploy_fastapi_to_minikube(manifest_dir: Path, image_name: Optional[str] = N
 
         # Apply service
         typer.echo(f"   Applying {service_file.name}...")
-        result = subprocess.run(
-            ["kubectl", "apply", "-f", str(service_file)] + ns,
+        result = run_tool(
+            "kubectl", ["apply", "-f", str(service_file)] + ns,
             check=True,
             capture_output=True,
             text=True
@@ -410,8 +411,8 @@ def deploy_fastapi_to_minikube(manifest_dir: Path, image_name: Optional[str] = N
 
         # Try minikube service --url with timeout (can hang)
         try:
-            result = subprocess.run(
-                ["minikube", "service", "fastapi-service", "--url"] + ns,
+            result = run_tool(
+                "minikube", ["service", "fastapi-service", "--url"] + ns,
                 capture_output=True,
                 text=True,
                 timeout=5  # 5 second timeout to prevent hanging
@@ -425,15 +426,15 @@ def deploy_fastapi_to_minikube(manifest_dir: Path, image_name: Optional[str] = N
         except (subprocess.TimeoutExpired, subprocess.CalledProcessError):
             # Fallback: get NodePort manually (more reliable)
             typer.echo("   Getting NodePort...")
-            result = subprocess.run(
-                ["kubectl", "get", "svc", "fastapi-service", "-o", "jsonpath='{.spec.ports[0].nodePort}'"] + ns,
+            result = run_tool(
+                "kubectl", ["get", "svc", "fastapi-service", "-o", "jsonpath='{.spec.ports[0].nodePort}'"] + ns,
                 capture_output=True,
                 text=True
             )
             if result.returncode == 0:
                 node_port = result.stdout.strip().strip("'")
-                minikube_ip_result = subprocess.run(
-                    ["minikube", "ip"],
+                minikube_ip_result = run_tool(
+                    "minikube", ["ip"],
                     capture_output=True,
                     text=True
                 )
@@ -446,8 +447,8 @@ def deploy_fastapi_to_minikube(manifest_dir: Path, image_name: Optional[str] = N
                 typer.echo("   Could not determine service URL. Check with: kubectl get svc fastapi-service")
 
         typer.echo("\n Deployment status:")
-        subprocess.run(["kubectl", "get", "pods", "-l", "app=fastapi"] + ns)
-        subprocess.run(["kubectl", "get", "svc", "-l", "app=fastapi"] + ns)
+        run_tool("kubectl", ["get", "pods", "-l", "app=fastapi"] + ns)
+        run_tool("kubectl", ["get", "svc", "-l", "app=fastapi"] + ns)
         
         return True
         
@@ -470,8 +471,8 @@ def load_image_to_minikube(image_name: str) -> bool:
         True if image was loaded or already exists, False otherwise
     """
     # Check if image exists locally
-    result = subprocess.run(
-        ["docker", "images", "-q", image_name],
+    result = run_tool(
+        "docker", ["images", "-q", image_name],
         capture_output=True,
         text=True
     )
@@ -482,8 +483,8 @@ def load_image_to_minikube(image_name: str) -> bool:
         return False
     
     # Check if image is already in minikube
-    result = subprocess.run(
-        ["minikube", "image", "ls"],
+    result = run_tool(
+        "minikube", ["image", "ls"],
         capture_output=True,
         text=True
     )
@@ -494,8 +495,8 @@ def load_image_to_minikube(image_name: str) -> bool:
     
     # Load image into minikube
     typer.echo(f"📦 Loading image '{image_name}' into minikube...")
-    result = subprocess.run(
-        ["minikube", "image", "load", image_name],
+    result = run_tool(
+        "minikube", ["image", "load", image_name],
         check=True,
         capture_output=True,
         text=True

--- a/src/deployml/utils/platform_compat.py
+++ b/src/deployml/utils/platform_compat.py
@@ -69,6 +69,15 @@ def run_tool(name: str, args: list, **kwargs) -> subprocess.CompletedProcess:
     as a direct subprocess.run call would.
     """
     resolved = resolve_tool(name)
+    # On Windows, when the caller captures output as text, subprocess decodes the
+    # child's bytes with the legacy cp1252 code page by default. Tools like minikube
+    # emit bytes that are invalid in cp1252, for example 0x9d, which raises
+    # UnicodeDecodeError. Decode as UTF-8 with replacement instead, the read side
+    # companion to configure_console_encoding. Only when no explicit encoding was
+    # requested, so callers keep full control.
+    if IS_WINDOWS and (kwargs.get("text") or kwargs.get("universal_newlines")):
+        kwargs.setdefault("encoding", "utf-8")
+        kwargs.setdefault("errors", "replace")
     try:
         return subprocess.run([resolved, *args], **kwargs)
     except OSError:

--- a/src/deployml/utils/platform_compat.py
+++ b/src/deployml/utils/platform_compat.py
@@ -82,6 +82,61 @@ def run_tool(name: str, args: list, **kwargs) -> subprocess.CompletedProcess:
         raise
 
 
+def find_windows_bash() -> "str | None":
+    """Absolute path to a real Windows bash (Git for Windows), or None.
+
+    On Windows the bash found first on PATH is often C:\\Windows\\System32\\bash.exe,
+    the WSL launcher. When a Windows process such as terraform.exe invokes it, the
+    WSL launcher re-translates the command line and strips embedded quoting, which
+    breaks Terraform local-exec scripts, for example gcloud --format="value(state)"
+    becomes an unquoted value(state) and bash errors on the parenthesis. Git for
+    Windows ships a normal bash that receives arguments unchanged, so prefer it.
+    Returns None off Windows or if no Git bash is found.
+    """
+    if not IS_WINDOWS:
+        return None
+    candidates = []
+    try:
+        # resolve_tool rejects the extensionless System32\git stub and returns the
+        # real git.exe, for example C:\Program Files\Git\cmd\git.exe.
+        git = resolve_tool("git")
+        git_root = os.path.dirname(os.path.dirname(git))  # ...\Git\cmd -> ...\Git
+        candidates.append(os.path.join(git_root, "bin", "bash.exe"))
+        candidates.append(os.path.join(git_root, "usr", "bin", "bash.exe"))
+    except FileNotFoundError:
+        pass
+    program_files = os.environ.get("ProgramFiles", r"C:\Program Files")
+    program_files_x86 = os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)")
+    local_appdata = os.environ.get("LOCALAPPDATA", "")
+    for base in (program_files, program_files_x86):
+        candidates.append(os.path.join(base, "Git", "bin", "bash.exe"))
+    if local_appdata:
+        candidates.append(os.path.join(local_appdata, "Programs", "Git", "bin", "bash.exe"))
+    for path in candidates:
+        if path and os.path.isfile(path):
+            return path
+    return None
+
+
+def terraform_env() -> "dict | None":
+    """Environment for running terraform so its local-exec provisioners resolve a
+    real Windows bash instead of the WSL launcher.
+
+    Returns None to mean "inherit the current environment unchanged", off Windows
+    or when no Git bash is found. On Windows with Git bash present, returns a copy
+    of the environment with the Git bash directory prepended to PATH, so terraform's
+    bare "bash" interpreter resolves there first, ahead of the WSL launcher in
+    System32.
+    """
+    bash = find_windows_bash()
+    if not bash:
+        return None
+    env = dict(os.environ)
+    bash_dir = os.path.dirname(bash)
+    env["PATH"] = bash_dir + os.pathsep + env.get("PATH", "")
+    return env
+
+
 def configure_console_encoding() -> None:
     """Force UTF-8 on Windows stdout and stderr so non ASCII output never crashes.
 

--- a/src/deployml/utils/platform_compat.py
+++ b/src/deployml/utils/platform_compat.py
@@ -1,0 +1,129 @@
+"""Cross platform helpers so the deployml CLI behaves identically on Windows,
+macOS, and Linux.
+
+All operating system awareness lives here. Command modules call run_tool instead
+of subprocess.run for external tools, call configure_console_encoding once at
+startup, and use robust_rmtree for workspace cleanup. This keeps every CLI command
+the same across operating systems while the engine adapts underneath.
+
+The Windows problems this module solves:
+
+- gcloud, bq, and gsutil ship as .cmd batch wrappers, not .exe files, so
+  subprocess.run with a bare name fails with FileNotFoundError, WinError 2.
+  resolve_tool finds the real wrapper and run_tool launches it.
+- The gcloud SDK and Docker also ship an extensionless launcher script beside the
+  real wrapper. subprocess cannot execute that script, so resolve_tool prefers an
+  executable extension and never returns the bare launcher.
+- The default console code page is cp1252, so printing emoji or box glyphs raises
+  UnicodeEncodeError. configure_console_encoding forces UTF-8 with replacement.
+- Workspace cleanup hits read only files and transient locks, so a plain rmtree
+  raises PermissionError. robust_rmtree clears the read only bit and retries.
+"""
+
+import os
+import shutil
+import stat
+import subprocess
+import sys
+import time
+
+IS_WINDOWS = os.name == "nt"
+
+# Extensions Windows treats as directly executable. resolve_tool uses these to
+# reject the extensionless launcher scripts that ship beside gcloud.cmd, bq.cmd,
+# gsutil.cmd, and docker.exe.
+_WINDOWS_EXEC_EXTS = (".exe", ".cmd", ".bat", ".com")
+
+
+def resolve_tool(name: str) -> str:
+    """Return the absolute path to an external tool, honoring PATHEXT on Windows.
+
+    On Windows shutil.which can return an extensionless launcher script that ships
+    alongside the real wrapper, for example the gcloud bash script next to
+    gcloud.cmd. subprocess cannot launch that script, so when the first match has
+    no executable extension we look specifically for a .cmd, .exe, or .bat wrapper.
+
+    Raises FileNotFoundError with an actionable message if the tool is missing.
+    """
+    path = shutil.which(name)
+    if path is None:
+        raise FileNotFoundError(
+            f"Required tool '{name}' was not found on PATH. "
+            f"Install it and reopen your shell, then retry."
+        )
+    if IS_WINDOWS and os.path.splitext(path)[1].lower() not in _WINDOWS_EXEC_EXTS:
+        for ext in (".cmd", ".exe", ".bat"):
+            candidate = shutil.which(name + ext)
+            if candidate:
+                return candidate
+    return path
+
+
+def run_tool(name: str, args: list, **kwargs) -> subprocess.CompletedProcess:
+    """Run an external command the same way on every operating system.
+
+    Resolves the tool to its real path so .cmd wrappers like gcloud.cmd work on
+    Windows. Pass the args list you would have passed after the tool name. Every
+    subprocess.run keyword argument passes through unchanged, so capture_output,
+    text, check, input, cwd, env, and stdout or stderr redirection behave exactly
+    as a direct subprocess.run call would.
+    """
+    resolved = resolve_tool(name)
+    try:
+        return subprocess.run([resolved, *args], **kwargs)
+    except OSError:
+        # Some Windows Python builds cannot launch a .cmd or .bat directly and
+        # raise OSError, WinError 193, when CreateProcess runs. That happens before
+        # the child process starts, so retrying through the command interpreter is
+        # safe and produces no duplicate side effects. Only batch wrappers need it.
+        if IS_WINDOWS and resolved.lower().endswith((".cmd", ".bat")):
+            comspec = os.environ.get("COMSPEC", "cmd.exe")
+            return subprocess.run([comspec, "/c", resolved, *args], **kwargs)
+        raise
+
+
+def configure_console_encoding() -> None:
+    """Force UTF-8 on Windows stdout and stderr so non ASCII output never crashes.
+
+    Emoji and box drawing glyphs in CLI messages raise UnicodeEncodeError on a
+    legacy cp1252 console. Reconfiguring with errors set to replace guarantees the
+    command keeps running even on a strict console, degrading an unprintable glyph
+    to a placeholder instead of crashing. No effect off Windows.
+    """
+    if not IS_WINDOWS:
+        return
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            # stdout or stderr was replaced by a plain object, for example under a
+            # test harness, so there is nothing to reconfigure.
+            continue
+        try:
+            reconfigure(encoding="utf-8", errors="replace")
+        except (ValueError, OSError):
+            pass
+
+
+def robust_rmtree(path) -> None:
+    """Remove a directory tree, surviving Windows read only files and brief locks.
+
+    Windows marks some files read only, which shutil.rmtree does not clear, and a
+    sync client or scanner can hold a file open for a moment, so a plain rmtree
+    raises PermissionError. The error handler clears the read only bit and retries,
+    then pauses briefly and retries once more before giving up.
+    """
+    def _handle(func, target, _exc):
+        try:
+            os.chmod(target, stat.S_IWRITE)
+            func(target)
+        except Exception:
+            time.sleep(0.2)
+            func(target)
+
+    if not os.path.exists(path):
+        return
+    try:
+        # Python 3.12 renamed the rmtree error callback from onerror to onexc.
+        shutil.rmtree(path, onexc=_handle)
+    except TypeError:
+        shutil.rmtree(path, onerror=_handle)

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,33 @@
+"""Unit tests for the deployml doctor checks. No real Docker daemon or GCP calls."""
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import deployml.diagnostics.doctor as doctor_mod
+from deployml.diagnostics.doctor import DeployMLDoctor, CheckStatus
+
+
+def test_docker_permissions_skips_when_docker_missing():
+    """When docker is not on PATH, the permissions check should SKIP cleanly
+    rather than emit a misleading FAIL. _check_docker already reports the
+    missing binary, so a second 'cannot run docker' failure is noise."""
+    d = DeployMLDoctor()
+    d.results.clear()
+    with patch.object(doctor_mod.shutil, "which", return_value=None), \
+         patch.object(doctor_mod, "run_tool", side_effect=FileNotFoundError("docker")):
+        d._check_docker_permissions()
+    assert len(d.results) == 1
+    result = d.results[0]
+    assert result.name == "Docker Permissions"
+    assert result.status == CheckStatus.SKIP
+
+
+def test_docker_permissions_pass_when_docker_runs():
+    """Regression lock: when docker is present and `docker ps` succeeds, the
+    check still reports PASS through the new guard."""
+    d = DeployMLDoctor()
+    d.results.clear()
+    ok = SimpleNamespace(returncode=0, stdout="", stderr="")
+    with patch.object(doctor_mod.shutil, "which", return_value="/usr/local/bin/docker"), \
+         patch.object(doctor_mod, "run_tool", return_value=ok):
+        d._check_docker_permissions()
+    assert d.results[0].status == CheckStatus.PASS

--- a/tests/test_gke_destroy.py
+++ b/tests/test_gke_destroy.py
@@ -1,0 +1,86 @@
+"""Unit tests for the GKE teardown disk-reclaim logic.
+
+Covers the fix for the orphaned PersistentDisk left by gke-destroy
+--delete-cluster: the in-cluster CSI driver reclaims a PVC's backing PD
+asynchronously, and deleting the cluster too soon orphans a billing disk. No real
+GCP or kubectl calls; run_tool is mocked at the boundary.
+"""
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import deployml.utils.kubernetes_gke as gke
+
+
+# ---------- disk_ref_from_volume_handle (pure parsing) ----------
+
+def test_disk_ref_from_zonal_volume_handle():
+    h = "projects/my-proj/zones/us-west1-a/disks/pvc-1234"
+    assert gke.disk_ref_from_volume_handle(h) == ("pvc-1234", "--zone", "us-west1-a")
+
+
+def test_disk_ref_from_regional_volume_handle():
+    h = "projects/my-proj/regions/us-west1/disks/pvc-abcd"
+    assert gke.disk_ref_from_volume_handle(h) == ("pvc-abcd", "--region", "us-west1")
+
+
+def test_disk_ref_from_volume_handle_none_for_garbage():
+    assert gke.disk_ref_from_volume_handle("") is None
+    assert gke.disk_ref_from_volume_handle("not-a-handle") is None
+    assert gke.disk_ref_from_volume_handle(None) is None
+
+
+# ---------- get_pvc_volume_handle (boundary mocked) ----------
+
+def test_get_pvc_volume_handle_returns_handle_when_bound():
+    def fake_run_tool(name, args, **kw):
+        if args[:2] == ["get", "pvc"]:
+            return SimpleNamespace(returncode=0, stdout="pv-xyz\n", stderr="")
+        if args[:2] == ["get", "pv"]:
+            return SimpleNamespace(
+                returncode=0, stdout="projects/p/zones/z/disks/pvc-1\n", stderr=""
+            )
+        raise AssertionError(f"unexpected call {args}")
+
+    with patch.object(gke, "run_tool", side_effect=fake_run_tool):
+        assert gke.get_pvc_volume_handle("mlflow-pvc") == "projects/p/zones/z/disks/pvc-1"
+
+
+def test_get_pvc_volume_handle_none_when_unbound():
+    with patch.object(gke, "run_tool",
+                      return_value=SimpleNamespace(returncode=0, stdout="", stderr="")):
+        assert gke.get_pvc_volume_handle("mlflow-pvc") is None
+
+
+# ---------- delete_gce_disk_if_exists (boundary mocked) ----------
+
+def test_delete_gce_disk_skips_when_already_gone():
+    """If the CSI driver already reclaimed the disk, describe fails and no delete
+    must be issued."""
+    calls = []
+
+    def fake_run_tool(name, args, **kw):
+        calls.append(args)
+        return SimpleNamespace(returncode=1, stdout="", stderr="NOT_FOUND")
+
+    with patch.object(gke, "run_tool", side_effect=fake_run_tool):
+        ok = gke.delete_gce_disk_if_exists("my-proj", ("pvc-1", "--zone", "us-west1-a"))
+    assert ok is True
+    assert all(a[:3] != ["compute", "disks", "delete"] for a in calls)
+
+
+def test_delete_gce_disk_deletes_when_present():
+    seq = [
+        SimpleNamespace(returncode=0, stdout="pvc-1\n", stderr=""),    # describe: found
+        SimpleNamespace(returncode=0, stdout="", stderr=""),           # delete
+        SimpleNamespace(returncode=1, stdout="", stderr="NOT_FOUND"),  # describe: gone
+    ]
+    calls = []
+
+    def fake_run_tool(name, args, **kw):
+        calls.append(args)
+        return seq.pop(0)
+
+    with patch.object(gke, "run_tool", side_effect=fake_run_tool):
+        ok = gke.delete_gce_disk_if_exists("my-proj", ("pvc-1", "--zone", "us-west1-a"))
+    assert ok is True
+    assert any(a[:3] == ["compute", "disks", "delete"] for a in calls)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -187,19 +187,19 @@ def test_gcp_preflight_exits_when_adc_missing(mock_auth, mock_adc):
 
 # ---------- check_gcp_adc ----------
 
-@patch("deployml.utils.helpers.subprocess.run")
+@patch("deployml.utils.helpers.run_tool")
 def test_check_gcp_adc_returncode_zero_true(mock_run):
     mock_run.return_value = MagicMock(returncode=0)
     assert check_gcp_adc() is True
 
 
-@patch("deployml.utils.helpers.subprocess.run")
+@patch("deployml.utils.helpers.run_tool")
 def test_check_gcp_adc_returncode_nonzero_false(mock_run):
     mock_run.return_value = MagicMock(returncode=1)
     assert check_gcp_adc() is False
 
 
-@patch("deployml.utils.helpers.subprocess.run")
+@patch("deployml.utils.helpers.run_tool")
 def test_check_gcp_adc_exception_returns_false(mock_run):
     mock_run.side_effect = OSError("boom")
     assert check_gcp_adc() is False
@@ -214,7 +214,7 @@ def test_check_bq_binary_missing_false(mock_which):
 
 
 @patch("deployml.utils.helpers.shutil.which")
-@patch("deployml.utils.helpers.subprocess.run")
+@patch("deployml.utils.helpers.run_tool")
 def test_check_bq_binary_present_and_runs(mock_run, mock_which):
     mock_which.return_value = "/usr/bin/bq"
     mock_run.return_value = MagicMock(returncode=0)
@@ -222,7 +222,7 @@ def test_check_bq_binary_present_and_runs(mock_run, mock_which):
 
 
 @patch("deployml.utils.helpers.shutil.which")
-@patch("deployml.utils.helpers.subprocess.run")
+@patch("deployml.utils.helpers.run_tool")
 def test_check_bq_binary_present_but_errors(mock_run, mock_which):
     mock_which.return_value = "/usr/bin/bq"
     mock_run.return_value = MagicMock(returncode=2)
@@ -238,7 +238,7 @@ def test_get_terraform_version_binary_missing(mock_which):
 
 
 @patch("deployml.utils.helpers.shutil.which")
-@patch("deployml.utils.helpers.subprocess.run")
+@patch("deployml.utils.helpers.run_tool")
 def test_get_terraform_version_parses_json(mock_run, mock_which):
     mock_which.return_value = "/usr/bin/terraform"
     mock_run.return_value = MagicMock(
@@ -249,7 +249,7 @@ def test_get_terraform_version_parses_json(mock_run, mock_which):
 
 
 @patch("deployml.utils.helpers.shutil.which")
-@patch("deployml.utils.helpers.subprocess.run")
+@patch("deployml.utils.helpers.run_tool")
 def test_get_terraform_version_bad_json_returns_none(mock_run, mock_which):
     mock_which.return_value = "/usr/bin/terraform"
     mock_run.return_value = MagicMock(returncode=0, stdout="not json")
@@ -258,19 +258,19 @@ def test_get_terraform_version_bad_json_returns_none(mock_run, mock_which):
 
 # ---------- validate_gcp_project ----------
 
-@patch("deployml.utils.helpers.subprocess.run")
+@patch("deployml.utils.helpers.run_tool")
 def test_validate_gcp_project_exists(mock_run):
     mock_run.return_value = MagicMock(returncode=0, stdout="my-project\n")
     assert validate_gcp_project("my-project") is True
 
 
-@patch("deployml.utils.helpers.subprocess.run")
+@patch("deployml.utils.helpers.run_tool")
 def test_validate_gcp_project_missing(mock_run):
     mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="not found")
     assert validate_gcp_project("ghost") is False
 
 
-@patch("deployml.utils.helpers.subprocess.run")
+@patch("deployml.utils.helpers.run_tool")
 def test_validate_gcp_project_stdout_mismatch(mock_run):
     # returncode 0 but stdout does not match the project id we asked for
     mock_run.return_value = MagicMock(returncode=0, stdout="other-project\n")
@@ -279,7 +279,7 @@ def test_validate_gcp_project_stdout_mismatch(mock_run):
 
 # ---------- validate_gcp_region ----------
 
-@patch("deployml.utils.helpers.subprocess.run")
+@patch("deployml.utils.helpers.run_tool")
 def test_validate_gcp_region_in_list(mock_run):
     helpers_mod._GCP_REGIONS_CACHE = None
     mock_run.return_value = MagicMock(
@@ -289,7 +289,7 @@ def test_validate_gcp_region_in_list(mock_run):
     assert validate_gcp_region("us-west1") is True
 
 
-@patch("deployml.utils.helpers.subprocess.run")
+@patch("deployml.utils.helpers.run_tool")
 def test_validate_gcp_region_not_in_list(mock_run):
     helpers_mod._GCP_REGIONS_CACHE = None
     mock_run.return_value = MagicMock(
@@ -299,7 +299,7 @@ def test_validate_gcp_region_not_in_list(mock_run):
     assert validate_gcp_region("mars-central1") is False
 
 
-@patch("deployml.utils.helpers.subprocess.run")
+@patch("deployml.utils.helpers.run_tool")
 def test_validate_gcp_region_lookup_failure_does_not_block(mock_run):
     helpers_mod._GCP_REGIONS_CACHE = None
     mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="oops")
@@ -315,7 +315,7 @@ def test_check_docker_daemon_binary_missing(mock_which):
 
 
 @patch("deployml.utils.helpers.shutil.which")
-@patch("deployml.utils.helpers.subprocess.run")
+@patch("deployml.utils.helpers.run_tool")
 def test_check_docker_daemon_up(mock_run, mock_which):
     mock_which.return_value = "/usr/local/bin/docker"
     mock_run.return_value = MagicMock(returncode=0)
@@ -323,7 +323,7 @@ def test_check_docker_daemon_up(mock_run, mock_which):
 
 
 @patch("deployml.utils.helpers.shutil.which")
-@patch("deployml.utils.helpers.subprocess.run")
+@patch("deployml.utils.helpers.run_tool")
 def test_check_docker_daemon_down(mock_run, mock_which):
     mock_which.return_value = "/usr/local/bin/docker"
     mock_run.return_value = MagicMock(returncode=1, stderr="cannot connect")
@@ -332,7 +332,7 @@ def test_check_docker_daemon_down(mock_run, mock_which):
 
 # ---------- get_missing_iam_roles ----------
 
-@patch("deployml.utils.helpers.subprocess.run")
+@patch("deployml.utils.helpers.run_tool")
 def test_get_missing_iam_roles_owner_short_circuits(mock_run):
     mock_run.side_effect = [
         MagicMock(returncode=0, stdout="me@example.com\n"),
@@ -345,7 +345,7 @@ def test_get_missing_iam_roles_owner_short_circuits(mock_run):
     assert get_missing_iam_roles("proj", required) == []
 
 
-@patch("deployml.utils.helpers.subprocess.run")
+@patch("deployml.utils.helpers.run_tool")
 def test_get_missing_iam_roles_some_missing(mock_run):
     mock_run.side_effect = [
         MagicMock(returncode=0, stdout="me@example.com\n"),
@@ -358,13 +358,13 @@ def test_get_missing_iam_roles_some_missing(mock_run):
     assert get_missing_iam_roles("proj", required) == ["roles/run.admin"]
 
 
-@patch("deployml.utils.helpers.subprocess.run")
+@patch("deployml.utils.helpers.run_tool")
 def test_get_missing_iam_roles_account_lookup_fails_returns_all(mock_run):
     mock_run.return_value = MagicMock(returncode=0, stdout="")
     assert get_missing_iam_roles("proj", ["roles/run.admin"]) == ["roles/run.admin"]
 
 
-@patch("deployml.utils.helpers.subprocess.run")
+@patch("deployml.utils.helpers.run_tool")
 def test_get_missing_iam_roles_policy_query_fails_returns_all(mock_run):
     mock_run.side_effect = [
         MagicMock(returncode=0, stdout="me@example.com\n"),

--- a/tests/test_platform_compat.py
+++ b/tests/test_platform_compat.py
@@ -1,0 +1,103 @@
+"""Unit tests for deployml.utils.platform_compat.
+
+These close the coverage gap noted in the macOS re-validation: the helper test
+suite mocks run_tool wholesale, so resolve_tool's resolve/raise contract and
+run_tool's kwarg passthrough were never exercised. No real external tools are
+launched; the only real side effect is rmtree on a pytest tmp_path.
+"""
+import os
+import stat
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import deployml.utils.platform_compat as pc
+
+
+# ---------- resolve_tool ----------
+
+def test_resolve_tool_returns_path_when_found():
+    with patch.object(pc.shutil, "which", return_value="/usr/local/bin/gcloud"):
+        assert pc.resolve_tool("gcloud") == "/usr/local/bin/gcloud"
+
+
+def test_resolve_tool_raises_filenotfound_when_missing():
+    with patch.object(pc.shutil, "which", return_value=None):
+        with pytest.raises(FileNotFoundError) as exc:
+            pc.resolve_tool("nonexistent-tool-xyz")
+    assert "nonexistent-tool-xyz" in str(exc.value)
+
+
+# ---------- run_tool ----------
+
+def test_run_tool_forwards_resolved_path_args_and_kwargs():
+    """run_tool must prepend the resolved path and pass every kwarg straight
+    through to subprocess.run. The whole blocker 1 refactor depends on this."""
+    completed = SimpleNamespace(returncode=0)
+    with patch.object(pc, "resolve_tool", return_value="/usr/local/bin/gcloud"), \
+         patch.object(pc.subprocess, "run", return_value=completed) as mock_run:
+        result = pc.run_tool("gcloud", ["version", "--quiet"],
+                             capture_output=True, check=True)
+    assert result is completed
+    mock_run.assert_called_once_with(
+        ["/usr/local/bin/gcloud", "version", "--quiet"],
+        capture_output=True, check=True,
+    )
+
+
+def test_run_tool_decodes_utf8_in_windows_text_mode():
+    """On Windows, text-mode captures must be decoded as UTF-8 with replacement
+    to avoid the cp1252 UnicodeDecodeError. Off Windows this branch is skipped."""
+    completed = SimpleNamespace(returncode=0)
+    with patch.object(pc, "IS_WINDOWS", True), \
+         patch.object(pc, "resolve_tool", return_value=r"C:\sdk\bin\gcloud.cmd"), \
+         patch.object(pc.subprocess, "run", return_value=completed) as mock_run:
+        pc.run_tool("gcloud", ["version"], text=True)
+    _, kwargs = mock_run.call_args
+    assert kwargs.get("encoding") == "utf-8"
+    assert kwargs.get("errors") == "replace"
+
+
+# ---------- robust_rmtree ----------
+
+def test_robust_rmtree_removes_directory_tree(tmp_path):
+    target = tmp_path / "ws"
+    (target / "sub").mkdir(parents=True)
+    (target / "sub" / "f.txt").write_text("data")
+    pc.robust_rmtree(str(target))
+    assert not target.exists()
+
+
+def test_robust_rmtree_is_noop_on_missing_path(tmp_path):
+    missing = tmp_path / "does-not-exist"
+    pc.robust_rmtree(str(missing))  # must not raise
+    assert not missing.exists()
+
+
+def test_robust_rmtree_removes_tree_with_readonly_file(tmp_path):
+    target = tmp_path / "ws"
+    target.mkdir()
+    ro = target / "ro.txt"
+    ro.write_text("x")
+    os.chmod(ro, stat.S_IREAD)
+    pc.robust_rmtree(str(target))
+    assert not target.exists()
+
+
+# ---------- configure_console_encoding ----------
+
+def test_configure_console_encoding_is_noop_off_windows():
+    fake_sys = SimpleNamespace(stdout=MagicMock(), stderr=MagicMock())
+    with patch.object(pc, "IS_WINDOWS", False), patch.object(pc, "sys", fake_sys):
+        assert pc.configure_console_encoding() is None
+    fake_sys.stdout.reconfigure.assert_not_called()
+    fake_sys.stderr.reconfigure.assert_not_called()
+
+
+def test_configure_console_encoding_forces_utf8_on_windows():
+    fake_sys = SimpleNamespace(stdout=MagicMock(), stderr=MagicMock())
+    with patch.object(pc, "IS_WINDOWS", True), patch.object(pc, "sys", fake_sys):
+        pc.configure_console_encoding()
+    fake_sys.stdout.reconfigure.assert_called_once_with(encoding="utf-8", errors="replace")
+    fake_sys.stderr.reconfigure.assert_called_once_with(encoding="utf-8", errors="replace")


### PR DESCRIPTION
## Summary

  Makes deployml run on native Windows using the exact same CLI commands as macOS and
  Linux. The command surface does not change. The engine detects the operating system
  and adapts underneath, so a Windows user runs the identical workflow:
  `doctor`, `init`, `build-images`, `deploy`, `get-urls`, `destroy`, and the GKE and
  minikube commands. Branched off `feat/gcp` so the Windows work layers on the
  validated GCP and Kubernetes base.

  ## New engine module

  All operating system awareness is centralized in one new module,
  `src/deployml/utils/platform_compat.py`, with `IS_WINDOWS`, `resolve_tool`,
  `run_tool`, `configure_console_encoding`, `robust_rmtree`, `find_windows_bash`, and
  `terraform_env`. Command code calls these helpers instead of branching on the OS.

  ## Windows blockers fixed

  1. **External tool execution.** gcloud, bq, and gsutil ship as `.cmd` wrappers on
     Windows, which `subprocess` could not launch by bare name. Every external tool
     call now routes through `run_tool`, which resolves the real executable and runs
     it. The helpers unit test mocks were updated to match the new call path.
  2. **Console encoding.** Emoji and box glyphs crashed the cp1252 console. UTF-8 is
     forced on the console at the CLI entry point, and captured subprocess output is
     also decoded as UTF-8 so it never raises on either the write or read side.
  3. **Cloud SQL Terraform provisioner.** The readiness check uses bash-only syntax
     and previously ran under cmd.exe. Added an explicit `bash` interpreter, and made
     Terraform resolve to Git bash on Windows rather than the WSL bash launcher.
  4. **Workspace cleanup.** `robust_rmtree` clears the read-only bit and retries so
     destroy cleanup survives read-only files and OneDrive locks.
  5. **GKE auth plugin.** Added an actionable message and PATH guidance when
     `gke-gcloud-auth-plugin` is missing, so kubectl can authenticate to GKE.
  6. **minikube runtime.** Documented the tunnel requirement for service URLs on the
     docker driver and the memory needed for MLflow.

  ## Live validation on native Windows

  - **Cloud Run**: full cycle, `init`, `build-images`, `deploy` to Apply complete with
    about 83 resources, all services returning HTTP 200, `destroy`, zero residual.
  - **GKE**: full cycle, Autopilot cluster, deploy, in-cluster MLflow connectivity,
    `destroy` with cluster delete, zero residual.
  - **minikube**: FastAPI and MLflow with a persistent volume, with data surviving a
    pod restart.
  - 45 unit tests pass, `doctor` runs clean, and `mkdocs build --strict` passes.

  ## Documentation

  Added native Windows setup and platform notes to `docs/installation.md` and the
  GKE plugin PATH and minikube notes to the tutorials, covering the toolchain, the
  venv, keeping the working directory off OneDrive, and the gcloud `.cmd` behavior.
