### PR TITLE
fix: make Grafana Cloud Run admin credentials configurable

### DIFF
--- a/src/deployml/docker/grafana-container/Dockerfile
+++ b/src/deployml/docker/grafana-container/Dockerfile
@@ -4,9 +4,7 @@ FROM grafana/grafana:10.4.5
 USER root
 
 # Configure Grafana to listen on Cloud Run's expected port
-ENV GF_SERVER_HTTP_PORT=8080 \
-    GF_SECURITY_ADMIN_USER=admin \
-    GF_SECURITY_ADMIN_PASSWORD=admin
+ENV GF_SERVER_HTTP_PORT=8080
 
 # Copy entrypoint script and set permissions 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/src/deployml/templates/gcp/cloud_run/main.tf.j2
+++ b/src/deployml/templates/gcp/cloud_run/main.tf.j2
@@ -201,6 +201,8 @@ module "{{ stage_name }}_{{ tool.name }}" {
   cpu_limit           = var.cpu_limit
   memory_limit        = var.memory_limit
   allow_public_access = var.allow_public_access
+  grafana_admin_user      = "{{ tool.params.get('grafana_admin_user', 'admin') }}"
+  grafana_admin_password  = "{{ tool.params.get('grafana_admin_password', 'admin') }}"
   {% if flags.needs_postgres %}
   metrics_connection_string = module.cloud_sql_postgres.grafana_connection_string_cloud_sql
   use_metrics_database = true

--- a/src/deployml/templates/gcp/cloud_run/mlflow_main.tf.j2
+++ b/src/deployml/templates/gcp/cloud_run/mlflow_main.tf.j2
@@ -280,6 +280,8 @@ module "{{ stage_name }}_{{ tool.name }}" {
   cpu_limit           = var.cpu_limit
   memory_limit        = var.memory_limit
   allow_public_access = var.allow_public_access
+  grafana_admin_user      = "{{ tool.params.get('grafana_admin_user', 'admin') }}"
+  grafana_admin_password  = "{{ tool.params.get('grafana_admin_password', 'admin') }}"
   {% if flags.needs_postgres %}
   metrics_connection_string = module.cloud_sql_postgres.grafana_connection_string_cloud_sql
   use_metrics_database = true

--- a/src/deployml/terraform/modules/grafana/cloud/gcp/cloud_run/main.tf
+++ b/src/deployml/terraform/modules/grafana/cloud/gcp/cloud_run/main.tf
@@ -48,6 +48,14 @@ resource "google_cloud_run_service" "grafana" {
           name  = "GF_SERVER_HTTP_PORT"
           value = "8080"
         }
+        env {
+          name  = "GF_SECURITY_ADMIN_USER"
+          value = var.grafana_admin_user
+        }
+        env {
+          name  = "GF_SECURITY_ADMIN_PASSWORD"
+          value = var.grafana_admin_password
+        }
       }
     }
   }

--- a/src/deployml/terraform/modules/grafana/cloud/gcp/cloud_run/variables.tf
+++ b/src/deployml/terraform/modules/grafana/cloud/gcp/cloud_run/variables.tf
@@ -53,3 +53,16 @@ variable "cloudsql_instance_annotation" {
   description = "Cloud SQL instance connection annotation"
   default     = ""
 }
+
+variable "grafana_admin_user" {
+  type        = string
+  description = "Admin username for Grafana"
+  default     = "admin"
+}
+
+variable "grafana_admin_password" {
+  type        = string
+  description = "Admin password for Grafana"
+  default     = "admin"
+  sensitive   = true
+}


### PR DESCRIPTION
## What

The Grafana admin credentials on the Cloud Run path were hardcoded to `admin`/`admin` and baked into the container image (Dockerfile `ENV`), with no way to override them at deploy time. This makes them configurable through the stack config and removes the secret from the image:

- Add `grafana_admin_user` / `grafana_admin_password` inputs to the Grafana Cloud Run module, wired to `GF_SECURITY_ADMIN_USER` / `GF_SECURITY_ADMIN_PASSWORD` (password marked `sensitive`). Defaults to `admin` to preserve current behavior.
- Forward those values from the grafana tool's `params` in both Cloud Run main templates (`main.tf.j2`, `mlflow_main.tf.j2`).
- Remove the baked-in `GF_SECURITY_ADMIN_*` `ENV` from the Grafana image.

## Why

Baking credentials into an image stores them in a readable layer (`docker history`) and leaves operators no way to set a real password. On stateless Cloud Run, an admin password changed via the UI does not survive a cold start (Grafana's SQLite config DB sits on ephemeral disk unless a metrics Postgres DB is configured), so supplying the password as deploy-time env is the correct pattern — this change makes that possible.

## Behavior

Unchanged by default: deployed services get `admin`/`admin` from Terraform, and a standalone image falls back to Grafana's own admin default, so documented logins still hold. Operators can now override by setting `grafana_admin_password` (and `grafana_admin_user`) in their stack config.

## Verification

Rendered the documented MLflow + Grafana stack through `mlflow_main.tf.j2`: it emits a single Grafana module with the credentials applied, and a custom password set in config passes through to the rendered Terraform. `terraform fmt` clean on the new module lines.

## Out of scope (follow-up)

While verifying, found a pre-existing bug: `main.tf.j2` emits the Grafana module twice (generic tool loop + dedicated block) and passes arguments the module doesn't declare, so Grafana via that path (a stack with no MLflow/W&B) cannot deploy today. It's independent of credentials and will be addressed separately.

## Test plan

- [x] Render documented MLflow+Grafana stack → single module, creds applied, custom password passes through
- [x] `terraform fmt` clean on the new module lines
- [ ] (maintainer) deploy a stack and confirm Grafana login with default and with an overridden password
