### PR TITLE
fix: stop emitting the Grafana module twice in the cloud_run template

### DIFF
--- a/src/deployml/templates/gcp/cloud_run/main.tf.j2
+++ b/src/deployml/templates/gcp/cloud_run/main.tf.j2
@@ -97,6 +97,7 @@ module "cloud_sql_postgres" {
         {% endif %}
       {% endfor %}
     {% endfor %}
+{% if not (stage_name == "model_monitoring" and tool.name == "grafana") %}
 module "{{ stage_name }}_{{ tool.name }}" {
   source = "./modules/{{ tool.name }}/cloud/{{ cloud }}/{{ deployment_type }}"
   count  = var.enable_{{ stage_name }}_{{ tool.name }} && var.{{ stage_name }}_{{ tool.name }}_service_name != "" ? 1 : 0
@@ -184,6 +185,7 @@ module "{{ stage_name }}_{{ tool.name }}" {
   create_bigquery_dataset = var.feast_create_bigquery_dataset
   {% endif %}
 }
+{% endif %}
   {% endfor %}
 {% endfor %}
 


### PR DESCRIPTION
## What

`main.tf.j2` (the Cloud Run template used when a stack has neither MLflow nor W&B) emitted the Grafana module **twice** — once from the generic per-tool loop and once from the dedicated Grafana block. The generic loop also passed arguments the Grafana Cloud Run module doesn't declare.

This excludes grafana from the generic loop so only the dedicated block emits it.

## Why

Two Terraform errors made Grafana undeployable via this template:
1. Duplicate `module "model_monitoring_grafana"` (duplicate module name).
2. Unsupported arguments (`cpu_request`, `max_scale`, `use_postgres`, …) passed to a module that doesn't declare them.

`mlflow_main.tf.j2` already avoids this by using dedicated per-tool blocks; this aligns `main.tf.j2` with that approach (exclude grafana from the catch-all, let the specialized block own it).

## Verification

Rendered `main.tf.j2` for grafana-containing stacks:
- grafana-only → **1** Grafana module (was 2), no stray args
- grafana + params → 1 module, no `x = var.x` junk (previously emitted, e.g. `grafana_port = var.grafana_port`)
- fastapi + grafana → fastapi still emits via the generic loop, grafana once (regression check: only grafana is excluded)

## Notes

Found while working on #61 (Grafana credentials) and deliberately scoped out of that PR to keep it focused. Independent change; touches different lines of the same file, so the two PRs do not conflict.

## Test plan

- [x] Render `main.tf.j2` across grafana / non-grafana stacks (counts above)
- [ ] (maintainer) deploy a grafana cloud_run stack and confirm `terraform apply` succeeds
