### PR TITLE
Add pytest scaffolding + first batch of unit tests for utils/helpers.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,12 @@ deployml = "deployml.cli.cli:main"
 [tool.poetry]
 packages = [{include = "deployml", from = "src"}]
 
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.0"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
 [tool.setuptools]
 include-package-data = true
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,1 @@
+# Pytest auto-discovers this file. Shared fixtures go here when we need them.

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,84 @@
+"""Unit tests for src/deployml/utils/helpers.py.
+
+First batch — covers three patterns:
+  1. Pure functions (no mocks needed)         → generate_bucket_name
+  2. Functions that call out to the OS        → check_command  (uses mocks)
+  3. Functions that parse text                → estimate_terraform_time
+"""
+
+from unittest.mock import patch
+
+from deployml.utils.helpers import (
+    check_command,
+    estimate_terraform_time,
+    generate_bucket_name,
+)
+
+
+# ---------------------------------------------------------------------------
+# generate_bucket_name — pure function, no I/O, easiest possible test
+# ---------------------------------------------------------------------------
+
+def test_generate_bucket_name_basic():
+    # Arrange + Act
+    name = generate_bucket_name("my-project-123")
+    # Assert
+    assert name == "mlflow-artifacts-my-project-123"
+
+
+def test_generate_bucket_name_replaces_underscores():
+    # GCS bucket names disallow underscores. The helper must convert them
+    # to hyphens — otherwise a project ID like "my_project" would produce
+    # an invalid bucket name and deploy would fail at apply time.
+    name = generate_bucket_name("my_project_123")
+    assert name == "mlflow-artifacts-my-project-123"
+    assert "_" not in name
+
+
+# ---------------------------------------------------------------------------
+# check_command — calls shutil.which under the hood. We mock it so the test
+# doesn't depend on what's installed on the machine running the suite.
+# ---------------------------------------------------------------------------
+
+def test_check_command_returns_true_when_found():
+    with patch("deployml.utils.helpers.shutil.which", return_value="/usr/bin/terraform"):
+        assert check_command("terraform") is True
+
+
+def test_check_command_returns_false_when_missing():
+    with patch("deployml.utils.helpers.shutil.which", return_value=None):
+        assert check_command("nonexistent-cmd") is False
+
+
+# ---------------------------------------------------------------------------
+# estimate_terraform_time — parses terraform plan output with regex.
+# We feed it realistic snippets and assert on the returned string.
+# ---------------------------------------------------------------------------
+
+def test_estimate_terraform_time_detects_cloud_sql():
+    # Cloud SQL gets a special 20-min-per-instance estimate because
+    # provisioning a Postgres instance is the slowest part of a deploy.
+    plan_output = """
+    Terraform will perform the following actions:
+
+      # google_sql_database_instance.main will be created
+      + resource "google_sql_database_instance" "main" {
+        name = "mlflow-db"
+      }
+    """
+    result = estimate_terraform_time(plan_output)
+    assert "20 minutes" in result
+    assert "Cloud SQL" in result
+
+
+def test_estimate_terraform_time_small_stack_without_cloud_sql():
+    # Two non-SQL resources → falls into the generic resource-count branch.
+    # 2 resources × 0.5 min avg = 1 minute (clamped by max(1, ...)).
+    plan_output = """
+      # google_cloud_run_service.mlflow will be created
+      # google_cloud_run_service.fastapi will be created
+    """
+    result = estimate_terraform_time(plan_output)
+    assert result.startswith("~")
+    assert "minute" in result
+    assert "Cloud SQL" not in result


### PR DESCRIPTION
## Summary

- Adds the first `tests/` directory in the repo, with `pytest` configured as a dev dependency in `pyproject.toml` and discovery pointed at `tests/`.
- Writes six unit tests against `src/deployml/utils/helpers.py`, deliberately chosen to cover three distinct testing patterns rather than six variations of one:
  - **Pure function** — `generate_bucket_name` (2 tests: normal project ID; ID with underscores → hyphens for GCS validity)
  - **Mocking the OS boundary** — `check_command` (2 tests: binary found, binary missing — `shutil.which` patched via `unittest.mock`)
  - **Parsing logic** — `estimate_terraform_time` (2 tests: Cloud SQL detected → 20-min estimate; small non-SQL stack → resource-count estimate)
- All six tests pass locally in <2s.

## Why this PR

The repo has no test scaffolding yet. Rather than add a large suite all at once, this PR establishes the infrastructure and demonstrates the three patterns future tests will lean on. Subsequent batches can extend `tests/test_helpers.py` (or split into more files) without touching the scaffolding.

Marking as draft so reviewers can weigh in on testing conventions (file layout, naming, fixture style) before more tests land.

## Test plan

- [ ] `python3 -m pytest -v` runs and reports `6 passed`
- [ ] `python3 -m pytest -k bucket` runs only the 2 bucket tests
- [ ] Reviewer confirms `tests/` layout + `pyproject.toml` config match the conventions they'd like to see going forward

## Notes / follow-ups

- No CI workflow added yet — intentional for this first PR. A GitHub Actions job that runs `pytest` on every PR is a small follow-up.
- No coverage tool (`pytest-cov`) added — also intentional, to keep the first batch focused.
- Next testing targets discussed: `copy_modules_to_workspace` (will need a `tmp_path` fixture), `bucket_exists` / `generate_unique_bucket_name` (will need to mock the `google.cloud.storage` client).