### PR TITLE
test: characterize single Grafana module rendering

### DIFF
--- a/tests/test_docker_discovery.py
+++ b/tests/test_docker_discovery.py
@@ -1,0 +1,17 @@
+"""Characterize the service discovery used by ``build_images``."""
+
+from pathlib import Path
+
+
+def test_build_images_discovers_exactly_the_current_gcp_services():
+    docker_root = Path(__file__).parents[1] / "src" / "deployml" / "docker"
+    services = {
+        directory.name
+        for directory in docker_root.iterdir()
+        if directory.is_dir() and (directory / "Dockerfile").exists()
+    }
+
+    assert services == {"fastapi", "grafana-container", "mlflow"}, (
+        "A new service directory requires per-provider filtering in build_images "
+        "(correction C5) before it can land."
+    )

--- a/tests/test_template_rendering.py
+++ b/tests/test_template_rendering.py
@@ -1,4 +1,5 @@
 """Characterize GCP cloud_run template rendering. No GCP calls, no subprocess."""
+
 import hashlib
 
 import pytest
@@ -12,10 +13,17 @@ def render_cloud_run():
     """Render templates/gcp/cloud_run/main.tf.j2 the same way cli.py's deploy
     command does, with the minimal kwargs the template can reference."""
 
-    def _render(provider: str, stack: list[dict], stack_name: str = "test-stack") -> str:
+    def _render(
+        provider: str,
+        stack: list[dict],
+        stack_name: str = "test-stack",
+        template_name: str = "main.tf.j2",
+    ) -> str:
         env = Environment(loader=FileSystemLoader(TEMPLATE_DIR))
-        template = env.get_template(f"{provider}/cloud_run/main.tf.j2")
-        name_hash = hashlib.sha1(f"{stack_name}:test-project".encode("utf-8")).hexdigest()[:6]
+        template = env.get_template(f"{provider}/cloud_run/{template_name}")
+        name_hash = hashlib.sha1(
+            f"{stack_name}:test-project".encode("utf-8")
+        ).hexdigest()[:6]
         return template.render(
             cloud=provider,
             stack=stack,
@@ -34,15 +42,19 @@ def render_cloud_run():
 
 
 def test_cloud_run_grafana_is_rendered_once(render_cloud_run):
-    rendered = render_cloud_run(
-        provider="gcp",
-        stack=[
-            {
-                "model_monitoring": {
-                    "name": "grafana",
-                    "params": {"service_name": "grafana-server"},
-                }
+    stack = [
+        {
+            "model_monitoring": {
+                "name": "grafana",
+                "params": {"service_name": "grafana-server"},
             }
-        ],
-    )
-    assert rendered.count('module "model_monitoring_grafana"') == 1
+        }
+    ]
+
+    for template_name in ("main.tf.j2", "mlflow_main.tf.j2"):
+        rendered = render_cloud_run(
+            provider="gcp",
+            stack=stack,
+            template_name=template_name,
+        )
+        assert rendered.count('module "model_monitoring_grafana"') == 1

--- a/tests/test_template_rendering.py
+++ b/tests/test_template_rendering.py
@@ -1,0 +1,48 @@
+"""Characterize GCP cloud_run template rendering. No GCP calls, no subprocess."""
+import hashlib
+
+import pytest
+from jinja2 import Environment, FileSystemLoader
+
+from deployml.utils.constants import TEMPLATE_DIR
+
+
+@pytest.fixture
+def render_cloud_run():
+    """Render templates/gcp/cloud_run/main.tf.j2 the same way cli.py's deploy
+    command does, with the minimal kwargs the template can reference."""
+
+    def _render(provider: str, stack: list[dict], stack_name: str = "test-stack") -> str:
+        env = Environment(loader=FileSystemLoader(TEMPLATE_DIR))
+        template = env.get_template(f"{provider}/cloud_run/main.tf.j2")
+        name_hash = hashlib.sha1(f"{stack_name}:test-project".encode("utf-8")).hexdigest()[:6]
+        return template.render(
+            cloud=provider,
+            stack=stack,
+            deployment_type="cloud_run",
+            create_artifact_bucket=False,
+            bucket_configs={},
+            project_id="test-project",
+            stack_name=stack_name,
+            name_hash=name_hash,
+            teardown_config=None,
+            teardown_cron_schedule="",
+            teardown_scheduled_timestamp=0,
+        )
+
+    return _render
+
+
+def test_cloud_run_grafana_is_rendered_once(render_cloud_run):
+    rendered = render_cloud_run(
+        provider="gcp",
+        stack=[
+            {
+                "model_monitoring": {
+                    "name": "grafana",
+                    "params": {"service_name": "grafana-server"},
+                }
+            }
+        ],
+    )
+    assert rendered.count('module "model_monitoring_grafana"') == 1

--- a/tests/test_template_rendering.py
+++ b/tests/test_template_rendering.py
@@ -41,7 +41,8 @@ def render_cloud_run():
     return _render
 
 
-def test_cloud_run_grafana_is_rendered_once(render_cloud_run):
+@pytest.mark.parametrize("template_name", ["main.tf.j2", "mlflow_main.tf.j2"])
+def test_cloud_run_grafana_is_rendered_once(render_cloud_run, template_name):
     stack = [
         {
             "model_monitoring": {
@@ -51,10 +52,9 @@ def test_cloud_run_grafana_is_rendered_once(render_cloud_run):
         }
     ]
 
-    for template_name in ("main.tf.j2", "mlflow_main.tf.j2"):
-        rendered = render_cloud_run(
-            provider="gcp",
-            stack=stack,
-            template_name=template_name,
-        )
-        assert rendered.count('module "model_monitoring_grafana"') == 1
+    rendered = render_cloud_run(
+        provider="gcp",
+        stack=stack,
+        template_name=template_name,
+    )
+    assert rendered.count('module "model_monitoring_grafana"') == 1


### PR DESCRIPTION
## Summary

First step of AWS ECS Fargate support. This PR is groundwork only — it adds test coverage and changes no runtime behavior.

Adds `tests/test_template_rendering.py`, a characterization test asserting the Grafana module is emitted exactly once by the `cloud_run` template. This locks in the fix from #62 so the AWS work can't silently regress it.

## Why this first

The AWS plan requires existing GCP behavior to stay green throughout. There was no test guarding that, so this establishes the baseline before any provider abstraction lands.

The test defines its fixture inline rather than adding `tests/conftest.py`, deliberately: `conftest.py` is one of the files #63 also adds, and there's no reason to contest it for one fixture.

## Known gap, fixed in the next commit

`cli.py` selects `mlflow_main.tf.j2` whenever the stack contains MLflow — which the documented stack always does — so this test currently guards a template the documented stack doesn't render. The follow-up extends the same assertion to `mlflow_main.tf.j2`. Flagging it here rather than quietly shipping partial coverage.

## What's coming on this branch

AWS support lands incrementally on this PR: provider config validation and seams, then the AWS Terraform foundation (VPC/RDS/S3/ECS), the database bootstrap container, and MLflow/FastAPI/Grafana on Fargate. Tasks touching `cli.py`, `doctor.py`, and `infracost.py` are sequenced behind #64 to avoid conflicting with the Infracost v2 work.

## Test plan

- [x] `pytest tests/ -v` — 64 passed
- [x] Rebased onto current `main`, conflict-free, suite still green
- [ ] Reviewer confirms the characterization matches intended `cloud_run` behavior
